### PR TITLE
docs: README.mdをワークフローの現状に合わせて更新

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,11 +192,28 @@ uv run pytest --cov=src --cov-report=html
 
 ### Pull Request設定
 
-自動PR作成は `.github/workflows/fetch-data.yml` で制御されます：
+自動PR作成は `.github/workflows/fetch-data.yml` で制御されます。config.ymlでの直接設定はサポートしていませんが、ワークフロー内で以下の形式が使用されます：
 
-- **タイトル**: コミットメッセージと同じ形式
-- **ラベル**: `data-update`, `automated` が自動付与
-- **本文**: 実行日時、対象期間、変更ファイル数を含む定型フォーマット
+```yaml
+# PRタイトル形式（ワークフロー内で自動生成）
+PR_TITLE: "データ更新: YYYY-MM-DD (N CSV files)"
+
+# PR本文テンプレート（ワークフロー内で定義）
+PR_BODY: |
+  ## 🤖 自動データ更新
+  ### 📊 更新内容
+  - 実行日時: YYYY-MM-DD
+  - 対象期間: START_YEAR - END_YEAR
+  - データタイプ: [対象データ種別]
+  - 変更CSVファイル数: N
+
+# 自動付与されるラベル
+PR_LABELS:
+  - data-update # データ更新PR用
+  - automated # 自動生成PR用
+```
+
+カスタマイズが必要な場合は、`.github/workflows/fetch-data.yml` の該当箇所を直接編集してください。
 
 ## 🧪 テスト
 


### PR DESCRIPTION
## 概要
README.mdを現在のプロジェクトの実装状況に合わせて更新しました。

## 変更内容
- 🔄 **自動実行スケジュール**: 毎日実行（17:00 JST）と週次実行（月曜19:00 JST）の2種類のワークフローを明記
- ✨ **新機能の追加**: 自動PR作成機能を主な機能リストに追加
- 📝 **手動実行オプション**: 3種類のワークフロー（汎用、毎日、週次）の選択肢を追加
- ⚙️ **設定項目**: PR設定項目を設定セクションに追加

## 背景
プロジェクトに以下の新しいワークフローが追加されたことを受けて、ドキュメントの更新が必要でした：
- `fetch-data-daily.yml` - 毎日の最新週データチェック
- `fetch-data-weekly.yml` - 週次の包括的データチェック
- `fetch-data-common.yml` - 再利用可能なワークフロー

## 確認事項
- [x] README.mdのフォーマットが正しく表示される
- [x] 新しいワークフローの説明が正確である
- [x] pre-commitによるフォーマット済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **ドキュメント**
  * 自動実行を日次（17:00 JST）と週次（17:30 JST）の2ワークフローに分割して明記
  * データ更新時の自動PR作成機能とPRタイトル/ラベル/本文の生成ルールを明記
  * 手動実行手順を各ワークフロー毎に分割・再番号化し、ワークフロー名を付与
  * GitHub Actions権限設定の手順を追加
  * 収集／保存／品質管理／通知設定と日次・週次チェック項目を詳細化
  * クイックスタート・インストール手順を各フロー対応で更新
<!-- end of auto-generated comment: release notes by coderabbit.ai -->