### PR TITLE
fix: PR作成時のファイルカウントをCSVファイルのみに限定

### DIFF
--- a/scripts/create_pr.sh
+++ b/scripts/create_pr.sh
@@ -127,10 +127,12 @@ if [ -z "$NEW_FILES" ] || [ -z "$MODIFIED_FILES" ]; then
   # 一度のgit diffで全ての変更情報を取得（パフォーマンス最適化）
   GIT_STATUS=$(git diff --cached --name-status)
   if [ -z "$NEW_FILES" ]; then
-    NEW_FILES=$(echo "$GIT_STATUS" | grep "^A" 2>/dev/null | wc -l | xargs)
+    # data/raw/配下のCSVファイルのみをカウント（メタデータは除外）
+    NEW_FILES=$(echo "$GIT_STATUS" | grep "^A" | grep -E '^A\s+data/raw/[^/]+\.csv$' 2>/dev/null | wc -l | xargs)
   fi
   if [ -z "$MODIFIED_FILES" ]; then
-    MODIFIED_FILES=$(echo "$GIT_STATUS" | grep "^M" 2>/dev/null | wc -l | xargs)
+    # data/raw/配下のCSVファイルのみをカウント（修正時も同様）
+    MODIFIED_FILES=$(echo "$GIT_STATUS" | grep "^M" | grep -E '^M\s+data/raw/[^/]+\.csv$' 2>/dev/null | wc -l | xargs)
   fi
 fi
 # CHANGED_FILESのデフォルト値設定


### PR DESCRIPTION
## Summary
- PR作成時のファイルカウントロジックを修正
- `data/raw/*.csv` のみをカウント対象とし、`.metadata/*.json` を除外
- 新規・更新ファイル数の正確性を向上

## 変更内容
- `scripts/create_pr.sh` のファイルカウント処理を改善
  - 新規ファイル（A）のカウント時に、data/raw配下のCSVファイルのみを対象とする正規表現フィルタを追加
  - 更新ファイル（M）のカウント時も同様のフィルタを適用
  - メタデータファイル（.metadata/*.json）をカウントから除外

## 効果
- PRタイトルに表示されるファイル数が、実際のデータファイル（CSV）の数と一致
- メタデータファイルの増減がPRタイトルに影響しない
- より直感的で分かりやすいPRタイトルの生成

## Test plan
- [x] スクリプトの構文チェック（pre-commit hooks通過）
- [ ] データ更新時のPR作成で正しいファイル数が表示されることを確認
- [ ] メタデータファイルが除外されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **改善**
  * コミットメッセージ生成時のファイル変更検出ロジックを改善しました。CSV ファイルの追跡がより正確になり、より詳細で正確なコミット履歴が得られるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->