### PR TITLE
fix: 既存ファイル再取得のデフォルト動作を改善

### DIFF
--- a/.github/workflows/fetch-data.yml
+++ b/.github/workflows/fetch-data.yml
@@ -4,39 +4,39 @@ on:
   workflow_dispatch:
     inputs:
       data_types:
-        description: "データタイプ（カンマ区切り、空の場合は全て）"
+        description: "📊 データタイプ (カンマ区切り。空欄=全タイプ取得)"
         required: false
         default: ""
       start_year:
-        description: "開始年（デフォルト: 現在年）"
+        description: "📅 開始年 (デフォルト: 現在年)"
         required: false
         default: ""
       end_year:
-        description: "終了年（デフォルト: 現在年）"
+        description: "📅 終了年 (デフォルト: 現在年)"
         required: false
         default: ""
       dry_run:
-        description: "テスト実行（データ取得のみでコミットしない）"
+        description: "🧪 テスト実行モード (データ取得のみ、コミット/PR作成なし)"
         required: false
         type: boolean
         default: false
       skip_existing:
-        description: "既存ファイルをスキップ（新規データのみ取得）"
+        description: "⏭️ 増分取得モード (ON=欠損期間のみ取得 / OFF=既存期間も再取得して更新チェック)"
         required: false
         type: boolean
-        default: true
+        default: false
       verify_continuity:
-        description: "データの連続性を検証（欠損チェック）"
+        description: "🔍 データ連続性検証 (欠損データの有無をチェック)"
         required: false
         type: boolean
         default: false
       auto_merge:
-        description: "PRを自動マージする（Branch protectionルールに従う）"
+        description: "🔀 PR自動マージ (Branch protectionルールに従う)"
         required: false
         type: boolean
         default: false
       force_merge_on_failure:
-        description: "データ処理失敗時でもPRを作成してマージする（警告: データ品質が保証されない可能性があります）"
+        description: "⚠️ 処理失敗時も強制マージ (警告: データ品質が保証されない可能性あり)"
         required: false
         type: boolean
         default: false
@@ -123,9 +123,9 @@ jobs:
             DRY_RUN="false"
           fi
 
-          # SKIP_EXISTINGのデフォルト値（手動実行時はtrue）
+          # SKIP_EXISTINGのデフォルト値（デフォルトはfalse: 既存期間も再取得して更新チェック）
           if [ -z "$SKIP_EXISTING" ]; then
-            SKIP_EXISTING="true"
+            SKIP_EXISTING="false"
           fi
 
           # VERIFY_CONTINUITYのデフォルト値
@@ -158,7 +158,7 @@ jobs:
           echo "  Start year: $START_YEAR"
           echo "  End year: $END_YEAR"
           echo "  Dry run: $DRY_RUN"
-          echo "  Skip existing: $SKIP_EXISTING"
+          echo "  Incremental mode (skip existing): $SKIP_EXISTING"
           echo "  Verify continuity: $VERIFY_CONTINUITY"
           echo "  Auto merge: $AUTO_MERGE"
           echo "  Force merge on failure: $FORCE_MERGE_ON_FAILURE"


### PR DESCRIPTION
## 概要

既存ファイルが存在する期間も再取得してデータの更新をチェックするように、ワークフローのデフォルト動作を改善しました。

## 変更内容

### 1. デフォルト動作の変更
- `skip_existing`のデフォルト値を`true` → `false`に変更
- **新しい動作**: デフォルトで既存期間も再取得して、ハッシュ比較でデータの更新を検出

### 2. ワークフロー入力パラメータの説明を改善
全てのワークフロー入力パラメータを絵文字付きで分かりやすく統一：

- 📊 データタイプ (カンマ区切り。空欄=全タイプ取得)
- 📅 開始年 (デフォルト: 現在年)
- 📅 終了年 (デフォルト: 現在年)
- 🧪 テスト実行モード (データ取得のみ、コミット/PR作成なし)
- **⏭️ 増分取得モード (ON=欠損期間のみ取得 / OFF=既存期間も再取得して更新チェック)**
- 🔍 データ連続性検証 (欠損データの有無をチェック)
- 🔀 PR自動マージ (Branch protectionルールに従う)
- ⚠️ 処理失敗時も強制マージ (警告: データ品質が保証されない可能性あり)

### 3. ログ出力の改善
- "Skip existing" → "Incremental mode (skip existing)"に変更して意味を明確化

## 背景

従来は`skip_existing=true`がデフォルトで、既存ファイルが存在する期間はスキップされていたため、以下の問題がありました：

- データが更新されても再取得されない
- 既存データの鮮度が保証されない
- 更新チェックには手動で`skip_existing=false`を指定する必要があった

## 動作の違い

### 変更前
- デフォルトで既存ファイルがある期間はスキップ（新規データのみ取得）
- データの更新は検出されない

### 変更後
- デフォルトで既存期間も再取得してハッシュ比較で更新を検出
- 必要に応じて「増分取得モード」をONにすれば欠損期間のみを取得可能

## 影響

### メリット
- データの鮮度が保証される
- 東京都側でデータが修正された場合も自動的に検出・更新される
- ユーザーは明示的にオプションを選択できる

### デメリット
- APIリクエスト数が増加する（ただし、重複データはスキップされる）

## テスト計画

- [ ] 手動実行でデフォルト動作を確認
- [ ] 増分取得モードONで欠損データのみ取得を確認
- [ ] 既存データの更新検出を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * ワークフロー入力の説明をより明確にし、絵文字ラベルを追加して表現を改善しました。
  * データ処理時の既存データをスキップするオプションのデフォルト動作を変更し、関連するログメッセージも更新されました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->