### PR TITLE
fix(workflow): disable cache for check-version-change job

### DIFF
--- a/.github/workflows/migrate-metadata.yml
+++ b/.github/workflows/migrate-metadata.yml
@@ -46,8 +46,9 @@ jobs:
       - name: Setup uv
         uses: astral-sh/setup-uv@v4
         with:
-          enable-cache: true
-          cache-dependency-glob: "uv.lock"
+          # check-version-change ジョブは依存関係不要 (re モジュールのみ使用)
+          # workflow_dispatch 時は早期終了するためキャッシュを無効化
+          enable-cache: false
 
       - name: Setup Python
         run: uv python install 3.11


### PR DESCRIPTION
## Summary
- `check-version-change` ジョブの uv キャッシュエラーを修正
- 依存関係不要なジョブでキャッシュを無効化

## 原因
`check-version-change` ジョブで `uv sync` を実行せずにキャッシュを有効にしていたため、Post job cleanup 時に以下のエラーが発生:

```
Error: Cache path /home/runner/work/_temp/setup-uv-cache does not exist on disk. 
This likely indicates that there are no dependencies to cache.
```

## 修正内容
- `check-version-change` ジョブの `setup-uv` ステップで `enable-cache: false` に変更
- このジョブは Python の組み込み `re` モジュールのみを使用
- `workflow_dispatch` 時は早期終了するため依存関係のキャッシュは不要

## Test plan
- [ ] 手動で workflow_dispatch を実行してエラーが解消されることを確認
- [ ] `migrate` ジョブは依然としてキャッシュが有効であることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **その他**
  * CI/CDワークフローの内部設定を最適化しました。ユーザーに対する機能的な影響はありません。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->