### PR TITLE
fix(workflow): migrate-metadataのファイル数パースを修正

### DIFF
--- a/.github/workflows/migrate-metadata.yml
+++ b/.github/workflows/migrate-metadata.yml
@@ -190,7 +190,10 @@ jobs:
           uv run python scripts/migrate_metadata.py --dry-run --target-version "${{ steps.params.outputs.target_version }}" 2>&1 | tee dry_run.log
 
           # マイグレーション対象があるか確認 (空の場合は0をデフォルト)
-          MIGRATED=$(grep "Migrated:" dry_run.log | awk '{print $2}')
+          # ログ形式: "2025-12-17 07:45:46 - INFO - Migrated:       7546"
+          # awk '{print $2}' だと時刻(07:45:46)を取得してしまうため、
+          # sedで "Migrated:" の後の数値を抽出する
+          MIGRATED=$(grep "Migrated:" dry_run.log | sed -E 's/.*Migrated:\s*([0-9]+).*/\1/')
           MIGRATED=${MIGRATED:-0}
           echo "migrated_count=$MIGRATED" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
## Summary
- migrate-metadata ワークフローでマイグレーション対象ファイル数のパースが誤っていた問題を修正
- ログ形式が `2025-12-17 07:45:46 - INFO - Migrated: 7546` のため、`awk '{print $2}'` では時刻を取得してしまっていた
- `sed` を使用して "Migrated:" の後の数値を正しく抽出するよう修正

## 問題
PR #162 のタイトルが以下のようになっていた：
```
メタデータ更新: バージョン1.0へマイグレーション (07:45:46ファイル)
```

本来は：
```
メタデータ更新: バージョン1.0へマイグレーション (7546ファイル)
```

## 原因
```bash
# 旧コード
MIGRATED=$(grep "Migrated:" dry_run.log | awk '{print $2}')
```

ログ出力:
```
2025-12-17 07:45:46 - INFO - Migrated:       7546
```

`awk '{print $2}'` はスペース区切りの2番目のフィールド = `07:45:46` (時刻) を取得していた。

## 修正
```bash
# 新コード
MIGRATED=$(grep "Migrated:" dry_run.log | sed -E 's/.*Migrated:\s*([0-9]+).*/\1/')
```

## Test plan
- [ ] ワークフローを手動実行して正しいファイル数が表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## バグ修正
* マイグレーション確認処理におけるファイルカウント抽出の精度を向上させました。タイムスタンプが誤ってカウント値として解析される問題を解決し、より信頼性の高い動作を実現しました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->