### PR TITLE
fix: migrate-metadataワークフローのMETADATA_VERSION参照先を修正

### DIFF
--- a/.github/workflows/migrate-metadata.yml
+++ b/.github/workflows/migrate-metadata.yml
@@ -20,7 +20,7 @@ on:
     branches:
       - main
     paths:
-      - "src/managers/storage_manager.py"
+      - "src/models/metadata.py"
 
 permissions:
   contents: write
@@ -64,12 +64,12 @@ jobs:
           fi
 
           # 前のコミットのファイルを一時的に取得
-          git show HEAD^:src/managers/storage_manager.py > /tmp/old_storage_manager.py 2>/dev/null || echo "" > /tmp/old_storage_manager.py
+          git show HEAD^:src/models/metadata.py > /tmp/old_metadata.py 2>/dev/null || echo "" > /tmp/old_metadata.py
 
           OLD_VERSION=$(uv run python -c "
           import re
           try:
-              content = open('/tmp/old_storage_manager.py').read()
+              content = open('/tmp/old_metadata.py').read()
               match = re.search(r'^METADATA_VERSION\s*=\s*[\"\\']([^\"\\']*)[\"\\']', content, re.MULTILINE)
               print(match.group(1) if match else '')
           except Exception:
@@ -78,7 +78,7 @@ jobs:
           NEW_VERSION=$(uv run python -c "
           import re
           try:
-              content = open('src/managers/storage_manager.py').read()
+              content = open('src/models/metadata.py').read()
               match = re.search(r'^METADATA_VERSION\s*=\s*[\"\\']([^\"\\']*)[\"\\']', content, re.MULTILINE)
               print(match.group(1) if match else '')
           except Exception:
@@ -155,7 +155,7 @@ jobs:
           import re
           import sys
           try:
-              content = open('src/managers/storage_manager.py').read()
+              content = open('src/models/metadata.py').read()
               match = re.search(r'^METADATA_VERSION\s*=\s*[\"\\']([^\"\\']*)[\"\\']', content, re.MULTILINE)
               if match:
                   print(match.group(1))
@@ -169,7 +169,7 @@ jobs:
 
               # バージョン抽出に失敗した場合はワークフローを停止
               if [ $? -ne 0 ] || [ -z "$TARGET_VERSION" ]; then
-                echo "::error::METADATA_VERSION の抽出に失敗しました。storage_manager.py を確認してください。"
+                echo "::error::METADATA_VERSION の抽出に失敗しました。metadata.py を確認してください。"
                 exit 1
               fi
             fi


### PR DESCRIPTION
## 概要

`migrate-metadata.yml` ワークフローが失敗していた問題を修正しました。

## 問題

ワークフローが `METADATA_VERSION` を `src/managers/storage_manager.py` から取得しようとしていましたが、実際には `src/models/metadata.py` の19行目に定義されていました。

エラーログ:
```
ERROR: METADATA_VERSION not found
Error: Process completed with exit code 1.
```

## 修正内容

以下の3箇所を `src/managers/storage_manager.py` から `src/models/metadata.py` に修正:

1. **pushトリガーのパス監視対象** (23行目)
   - `METADATA_VERSION` の変更を正しく検出するため

2. **バージョン変更検出のファイル参照** (67行目, 81行目)
   - 旧バージョンと新バージョンの比較を正しく行うため

3. **フォールバック時のバージョン抽出** (158行目)
   - 手動実行時のバージョン検出を正しく行うため

4. **エラーメッセージの更新** (172行目)
   - 正しいファイル名を表示するため

## 検証

- ✅ ワークフローファイルのYAML構文チェックをパス
- ✅ pre-commitフックをすべてパス

## 関連

- 関連ワークフロー: `.github/workflows/migrate-metadata.yml`
- 定義ファイル: `src/models/metadata.py:19`