### PR TITLE
ci: DependabotのPRでClaudeレビューをスキップするように設定

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,11 +12,8 @@ on:
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
+    # Dependabotによる自動更新PRはスキップ
+    if: github.event.pull_request.user.login != 'dependabot[bot]'
 
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## Summary

DependabotによるPR (#182, #183など) でClaudeコードレビューが失敗扱いになっていた問題を修正。

## 変更内容

- `.github/workflows/claude-code-review.yml`に`if`条件を追加
- `dependabot[bot]`によるPRではジョブ自体をスキップ
- 既存のコメントアウトされたフィルター例を削除し、シンプルな条件式に変更

## 動作

- **通常のPR**: これまで通りClaudeレビューが実行される
- **DependabotのPR**: ジョブがスキップされ、失敗扱いにならない

## テスト計画

- [ ] このPR自体でClaudeレビューが実行されることを確認
- [ ] 既存のDependabot PR (#182, #183) で新しいコミットがプッシュされた際にレビューがスキップされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * CI/CDワークフローの改善により、自動依存関係アップデートプルリクエストの処理効率が向上しました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->