### PR TITLE
fix: Remove str() conversion for matplotlib color parameter

### DIFF
--- a/scripts/generate_charts.py
+++ b/scripts/generate_charts.py
@@ -760,7 +760,7 @@ def generate_absolute_chart(
         line = ax.plot(range(len(all_periods)), values, marker="o", linewidth=2.5, label=label_with_value, markersize=5)
 
         # 最新データポイントにアノテーションを追加 (共通関数を使用)
-        _add_annotation(ax, values, value_format, str(line[0].get_color()), JAPANESE_FONT, check_non_zero=True)
+        _add_annotation(ax, values, value_format, line[0].get_color(), JAPANESE_FONT, check_non_zero=True)
 
     # X軸ラベル (期間を明示)
     xlabel_text = _format_period_label(min_period, max_period, period_type)
@@ -876,9 +876,7 @@ def generate_deviation_chart(
         line = ax.plot(range(len(all_periods)), values, marker="o", linewidth=2.5, label=label_with_value, markersize=5)
 
         # 最新データポイントにアノテーションを追加 (共通関数を使用)
-        _add_annotation(
-            ax, values, f"{latest_value:+.0f}%", str(line[0].get_color()), JAPANESE_FONT, check_non_zero=True
-        )
+        _add_annotation(ax, values, f"{latest_value:+.0f}%", line[0].get_color(), JAPANESE_FONT, check_non_zero=True)
 
     # ベースライン (0%ライン) を表示
     if len(all_periods) > 0:


### PR DESCRIPTION
## 問題

GitHub Actionsでグラフ生成時に以下のエラーが発生:

```
ValueError: '(0.9677975592919913, 0.44127456009157356, 0.5358103155058701)' is not a valid value for color
```

## 原因

`scripts/generate_charts.py` の以下2箇所で、matplotlib の `annotate()` 関数に色パラメータを渡す際、`str(line[0].get_color())` で文字列化されたタプルを渡していたため。

matplotlibは色パラメータとして:
- タプル形式 `(r, g, b)` または `(r, g, b, a)` ✅
- 文字列形式 `"(r, g, b)"` ❌ (これが原因でエラー)

## 修正内容

- `generate_absolute_chart()` (763行目): `str()` を削除
- `generate_deviation_chart()` (880行目): `str()` を削除

```python
# 修正前
_add_annotation(ax, values, value_format, str(line[0].get_color()), JAPANESE_FONT)

# 修正後
_add_annotation(ax, values, value_format, line[0].get_color(), JAPANESE_FONT)
```

## 検証

ローカルで `uv run python scripts/generate_charts.py` を実行し、全グラフが正常に生成されることを確認:

```
✅ 定点報告疾患の週次推移グラフを生成: docs/images/sentinel_weekly_absolute.png
✅ 定点報告疾患の週次乖離率グラフを生成: docs/images/sentinel_weekly_deviation.png
✅ 全数報告疾患の週次推移グラフを生成: docs/images/notifiable_weekly_absolute.png
✅ 全数報告疾患の週次乖離率グラフを生成: docs/images/notifiable_weekly_deviation.png
✅ 定点報告疾患の月次推移グラフを生成: docs/images/sentinel_monthly_absolute.png
✅ 定点報告疾患の月次乖離率グラフを生成: docs/images/sentinel_monthly_deviation.png
```

## 影響範囲

- グラフ生成処理のみ
- データ取得・保存処理には影響なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## バグ修正
* チャート生成時のアノテーション機能における色の処理を改善しました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->