### PR TITLE
fix: Update type annotation for line_color parameter

### DIFF
--- a/scripts/generate_charts.py
+++ b/scripts/generate_charts.py
@@ -46,14 +46,16 @@ def _copy_font_properties(base_fp, size: float):
     return fp
 
 
-def _add_annotation(ax, values: list, value_text: str, line_color: str, japanese_font, check_non_zero: bool = True):
+def _add_annotation(
+    ax, values: list, value_text: str, line_color: str | tuple, japanese_font, check_non_zero: bool = True
+):
     """グラフにアノテーションを追加 (最新の非None値に対して)
 
     Args:
         ax: matplotlibのAxesオブジェクト
         values: データ値のリスト (Noneを含む可能性あり)
         value_text: 表示するテキスト (例: "123", "+45%")
-        line_color: アノテーションの色 (線の色と同じ)
+        line_color: アノテーションの色 (文字列またはRGBタプル)
         japanese_font: 日本語フォント (FontPropertiesオブジェクト、またはNone)
         check_non_zero: Trueの場合は最新値が0でないときのみ追加
     """


### PR DESCRIPTION
## 問題

PR #210マージ後、CI/CDのmypy型チェックで以下のエラーが発生:

```
scripts/generate_charts.py:763: error: Argument 4 to "_add_annotation" has incompatible type 
"tuple[float, float, float] | str | ..." expected "str" [arg-type]
```

## 原因

PR #210で`str(line[0].get_color())`から`line[0].get_color()`に修正したことで、matplotlibのカラータプルが直接渡されるようになりましたが、`_add_annotation()`関数の型定義が`line_color: str`のままだったため、型エラーが発生。

## 修正内容

`_add_annotation()`関数のline_colorパラメータの型ヒントを修正:

```python
# 修正前
def _add_annotation(ax, values: list, value_text: str, line_color: str, ...)

# 修正後
def _add_annotation(ax, values: list, value_text: str, line_color: str | tuple, ...)
```

matplotlibは色として以下の形式を受け付けるため:
- 文字列: `"red"`, `"#FF0000"`
- RGBタプル: `(0.96, 0.44, 0.53)`
- RGBAタプル: `(0.96, 0.44, 0.53, 1.0)`

## 検証

```bash
$ uv run mypy scripts/generate_charts.py
Success: no issues found in 1 source file
```

## 関連PR

- #210 (matplotlib color parameterのstr()削除)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

このPRには、エンドユーザーに目に見える変更はありません。内部実装の改善のみが含まれています。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->