### PR TITLE
fix: PRタイトルのファイル数カウントをstats.jsonから取得

### DIFF
--- a/scripts/create_pr.sh
+++ b/scripts/create_pr.sh
@@ -166,8 +166,35 @@ NEW_FILES="${NEW_FILES:-}"
 MODIFIED_FILES="${MODIFIED_FILES:-}"
 CHANGED_FILES="${CHANGED_FILES:-}"
 
-# 環境変数が設定されているか確認
-if [ -z "$NEW_FILES" ] || [ -z "$MODIFIED_FILES" ]; then
+# 優先順位1: stats.jsonから読み取る（最も正確）
+# データ取得スクリプトが記録した実際の処理結果を使用
+STATS_JSON_PATH="data/logs/stats_${FETCH_TIMESTAMP}.json"
+if [ -f "$STATS_JSON_PATH" ] && command -v jq >/dev/null 2>&1; then
+  echo "Reading file counts from stats.json..." >&2
+  if jq -e . "$STATS_JSON_PATH" >/dev/null 2>&1; then
+    STATS_NEW=$(jq -r '.new_files // 0' "$STATS_JSON_PATH" 2>/dev/null || echo "0")
+    STATS_UPDATED=$(jq -r '.updated_files // 0' "$STATS_JSON_PATH" 2>/dev/null || echo "0")
+
+    # 数値検証
+    if [[ "$STATS_NEW" =~ ^[0-9]+$ ]] && [[ "$STATS_UPDATED" =~ ^[0-9]+$ ]]; then
+      NEW_FILES="$STATS_NEW"
+      MODIFIED_FILES="$STATS_UPDATED"
+      echo "✓ Using stats.json: new=$NEW_FILES, updated=$MODIFIED_FILES (source: stats.json)" >&2
+      STATS_READ_SUCCESS=true
+    else
+      echo "⚠️ Warning: Invalid numbers in stats.json, falling back to other methods" >&2
+      STATS_READ_SUCCESS=false
+    fi
+  else
+    echo "⚠️ Warning: stats.json is not valid JSON, falling back to other methods" >&2
+    STATS_READ_SUCCESS=false
+  fi
+else
+  STATS_READ_SUCCESS=false
+fi
+
+# 優先順位2: 環境変数が設定されているか確認
+if [ "$STATS_READ_SUCCESS" != "true" ] && { [ -z "$NEW_FILES" ] || [ -z "$MODIFIED_FILES" ]; }; then
   echo "Calculating file counts from git diff..." >&2
   # 一度のgit diffで全ての変更情報を取得（パフォーマンス最適化）
   GIT_STATUS=$(git diff --cached --name-status)
@@ -197,7 +224,7 @@ if [ -z "$NEW_FILES" ] || [ -z "$MODIFIED_FILES" ]; then
       ;;
   esac
   echo "✓ Using git diff data: new=$NEW_FILES, updated=$MODIFIED_FILES (source: git diff)" >&2
-else
+elif [ "$STATS_READ_SUCCESS" != "true" ]; then
   echo "✓ Using environment variables: new=$NEW_FILES, updated=$MODIFIED_FILES (source: environment)" >&2
 fi
 


### PR DESCRIPTION
## 🐛 問題

PRタイトルが実際のファイル数と一致していない問題を修正しました。

### 発生していた問題
- PRタイトル: `データ更新: 2025-12-25 - 0件 (新規0件/更新0件)`
- 実際のデータ: **新規5件、更新294件**
- `stats.json`には正しい値が記録されていたが、`create_pr.sh`が読み取っていなかった

### 原因
`create_pr.sh`がファイル数を取得する際、以下の順序で処理していました:
1. 環境変数（`NEW_FILES`, `MODIFIED_FILES`）
2. git diff によるカウント

しかし、**stats.jsonを読み取っていなかった**ため、実際の処理結果（重複スキップなど）を反映できていませんでした。

## ✅ 修正内容

### ファイル数取得の優先順位を変更

```bash
# 優先順位1: stats.jsonから読み取る（最も正確）
STATS_JSON_PATH="data/logs/stats_${FETCH_TIMESTAMP}.json"
if [ -f "$STATS_JSON_PATH" ] && command -v jq >/dev/null 2>&1; then
  STATS_NEW=$(jq -r '.new_files // 0' "$STATS_JSON_PATH")
  STATS_UPDATED=$(jq -r '.updated_files // 0' "$STATS_JSON_PATH")
  # ...
fi

# 優先順位2: 環境変数（ワークフローから渡された値）
# 優先順位3: git diff（フォールバック）
```

### 変更後の動作
- ✅ stats.jsonが存在する場合: 実際の処理結果を使用
- ✅ stats.jsonが存在しない場合: 環境変数 → git diff の順でフォールバック
- ✅ エラーハンドリング強化: JSON検証、数値検証を追加

## 📊 影響範囲

- **次回のデータ更新PRから正確なファイル数が表示される**
- 既存のPRには影響なし
- バックワード互換性あり（stats.jsonがない場合は従来通りの動作）

## 🧪 テスト結果

```bash
$ bash -c 'STATS_JSON_PATH="data/logs/stats_20251225_162654.json"; 
  STATS_NEW=$(jq -r ".new_files" "$STATS_JSON_PATH");
  echo "NEW: $STATS_NEW"'
NEW: 5
```

## 📝 チェックリスト

- [x] コード修正完了
- [x] ローカルテスト成功
- [x] エラーハンドリング追加
- [x] バックワード互換性確保
- [x] コミットメッセージ記載

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * プルリクエスト生成プロセスを強化し、複数のデータソースから情報を取得する際の信頼性を向上させました。
  * ファイルカウント情報の精度を改善し、異なるデータソースの優先順位を最適化しました。
  * 統計データが利用できない場合のフォールバック機能を実装しました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->