### PR TITLE
fix: DataProcessor でファイル名が短い場合の IndexError を修正

### DIFF
--- a/src/processors/data_processor.py
+++ b/src/processors/data_processor.py
@@ -532,12 +532,20 @@ class DataProcessor:
             # notifiable_weekly_2025_01.csv
             if filename.startswith("notifiable_"):
                 parts = filename.replace(".csv", "").split("_")
+                # 最低4要素必要: notifiable, frequency, year, period
+                if len(parts) < 4:
+                    logger.warning(f"Invalid notifiable filename format (too short): {filename}")
+                    return None
                 return {"category": "notifiable", "frequency": parts[1], "year": parts[2], "period": parts[3]}
 
             # sentinel_weekly_gender_2025_01.csv
             # sentinel_monthly_health_center_2025_01.csv (aggregationが2単語の場合もある)
             if filename.startswith("sentinel_"):
                 parts = filename.replace(".csv", "").split("_")
+                # 最低4要素必要: sentinel, frequency, year, period (aggregationは空でもよい)
+                if len(parts) < 4:
+                    logger.warning(f"Invalid sentinel filename format (too short): {filename}")
+                    return None
                 # 最後の2つは必ず year と period
                 year = parts[-2]
                 period = parts[-1]
@@ -556,7 +564,7 @@ class DataProcessor:
 
             return None
 
-        except (KeyError, ValueError, AttributeError):
+        except (KeyError, ValueError, AttributeError, IndexError):
             logger.exception(f"メタデータ抽出失敗: {filename}")
             return None
 

--- a/tests/test_data_processor.py
+++ b/tests/test_data_processor.py
@@ -305,6 +305,28 @@ class TestDataProcessor(unittest.TestCase):
         self.assertEqual(metadata["year"], "2025")
         self.assertEqual(metadata["period"], "01")
 
+    def test_extract_metadata_from_short_filenames(self):
+        """短いファイル名でIndexErrorが発生せずNoneを返すことを確認"""
+        # 短いnotifiableファイル名(3要素未満)
+        metadata = self.processor._extract_metadata_from_filename("notifiable_weekly.csv")
+        self.assertIsNone(metadata, "Short notifiable filename should return None")
+
+        # 短いsentinelファイル名(3要素未満)
+        metadata = self.processor._extract_metadata_from_filename("sentinel_weekly.csv")
+        self.assertIsNone(metadata, "Short sentinel filename should return None")
+
+        # さらに短いsentinelファイル名(2要素未満)
+        metadata = self.processor._extract_metadata_from_filename("sentinel.csv")
+        self.assertIsNone(metadata, "Very short sentinel filename should return None")
+
+        # 1要素のみ
+        metadata = self.processor._extract_metadata_from_filename("notifiable.csv")
+        self.assertIsNone(metadata, "Single element filename should return None")
+
+        # 空のファイル名
+        metadata = self.processor._extract_metadata_from_filename(".csv")
+        self.assertIsNone(metadata, "Empty filename should return None")
+
     def test_detect_gender_sections(self):
         """性別セクション検出のテスト"""
         lines = [


### PR DESCRIPTION
## 概要
issue #219 を解決: `DataProcessor._extract_metadata_from_filename()` で短いファイル名 (例: `sentinel_weekly.csv`) の場合に `IndexError` が発生し、処理全体が中断される問題を修正しました。

## 問題
- `sentinel_` や `notifiable_` で始まる短いファイル名に対して、`parts[1]`, `parts[-2]` などにアクセスする際に `IndexError` が発生
- 例外ハンドリングが `KeyError/ValueError/AttributeError` のみで `IndexError` を捕捉していなかった
- 不正なファイル名1つで処理全体が落ちる

## 解決策
1. **早期チェックを追加**: `len(parts) >= 4` をチェックし、満たさない場合は `None` で早期return
   - notifiable_: 最低4要素 (notifiable, frequency, year, period) を要求
   - sentinel_: 最低4要素 (sentinel, frequency, year, period) を要求
2. **IndexError を例外ハンドリングに追加**: `except (KeyError, ValueError, AttributeError, IndexError)`
3. **警告ログを出力**: 不正なファイル名は warning ログを出力して安全にスキップ

## テスト結果
```bash
# 新しいテスト
✅ test_extract_metadata_from_short_filenames: 5パターンの短いファイル名でNoneを返すことを確認

# 全テスト
✅ 30 passed in 0.65s
```

## テストケース
- `notifiable_weekly.csv` → None (3要素未満)
- `sentinel_weekly.csv` → None (3要素未満)  
- `sentinel.csv` → None (2要素未満)
- `notifiable.csv` → None (1要素のみ)
- `.csv` → None (空のファイル名)

## 影響範囲
- 既存の正常なファイル名: 影響なし (全30テストが成功)
- 短いファイル名: 安全にスキップし、処理継続

## 受け入れ条件
- ✅ 不正なファイル名はスキップし処理継続
- ✅ テスト追加: 短い sentinel/notifiable 名のファイルで graceful fail
- ✅ 既存のテストが全て成功

Closes #219

🤖 Generated with [Claude Code](https://claude.com/claude-code)