### PR TITLE
fix: validate_data で警告が valid=False 時のみ集計される問題を修正

### DIFF
--- a/scripts/validate_data.py
+++ b/scripts/validate_data.py
@@ -83,7 +83,8 @@ class DataValidator:
             result["checks"]["file_size"] = size_result
             if not size_result["valid"]:
                 result["errors"].extend(size_result.get("errors", []))
-                result["warnings"].extend(size_result.get("warnings", []))
+            # warningsはvalidに関係なく常に収集
+            result["warnings"].extend(size_result.get("warnings", []))
             if size_result.get("details"):
                 details.update(size_result["details"])
 
@@ -101,7 +102,8 @@ class DataValidator:
                 result["checks"]["csv_format"] = csv_result
                 if not csv_result["valid"]:
                     result["errors"].extend(csv_result.get("errors", []))
-                    result["warnings"].extend(csv_result.get("warnings", []))
+                # warningsはvalidに関係なく常に収集
+                result["warnings"].extend(csv_result.get("warnings", []))
                 if csv_result.get("details"):
                     details.update(csv_result["details"])
 
@@ -121,9 +123,11 @@ class DataValidator:
             if result["errors"]:
                 result["valid"] = False
                 self.has_errors = True
-            elif result["warnings"] and self.strict_mode:
-                result["valid"] = False
+            # warningsは常に記録し、strictモード時はinvalidにする
+            if result["warnings"]:
                 self.has_warnings = True
+                if self.strict_mode:
+                    result["valid"] = False
 
         except Exception as e:
             self.logger.exception(f"Unexpected error validating {file_path}")

--- a/tests/test_validate_data.py
+++ b/tests/test_validate_data.py
@@ -90,6 +90,53 @@ class TestDataValidatorMarkdownReport(unittest.TestCase):
         self.assertIn("## ⚠️ 警告", report)
         self.assertIn("Inconsistent column count", report)
 
+    def test_warnings_collected_even_when_valid(self):
+        """CSVフォーマットチェックでvalidでもwarningsが収集されることを確認 (issue #218)"""
+        # テスト用CSVファイルを作成 (不整合な列数のwarningが出る)
+        test_file = self.data_dir / "test_warning.csv"
+        # 1行目は3列、2行目は2列で不整合
+        # ファイルサイズチェックをクリアするため、十分なデータを追加
+        content = "col1,col2,col3\n" + "val1,val2\n" * 10  # 100バイト以上になるように
+        test_file.write_bytes(content.encode("shift_jis"))
+
+        # 通常モード (strict=False)
+        validator = DataValidator(strict_mode=False)
+        result = validator.validate_file(test_file)
+
+        # 修正前: csv_formatがvalidの場合、warningsが収集されなかった
+        # 修正後: csv_formatがvalidでも、warningsは収集される
+        csv_result = result["checks"]["csv_format"]
+        self.assertTrue(csv_result["valid"], "CSV format should be valid (no errors)")
+        self.assertTrue(len(csv_result["warnings"]) > 0, "CSV format should have warnings")
+
+        # warningsは全体のresultにも収集される
+        self.assertTrue(len(result["warnings"]) > 0, "warnings should be collected in result")
+        self.assertIn(
+            "[csv_format] Inconsistent column count", result["warnings"], "CSV warnings should be in result['warnings']"
+        )
+
+        # has_warningsがTrueになる(strictモードでなくても)
+        self.assertTrue(validator.has_warnings, "has_warnings should be True even in normal mode")
+
+    def test_warnings_make_invalid_in_strict_mode(self):
+        """strictモード時にwarningsがあるとinvalidになることを確認 (issue #218)"""
+        # テスト用CSVファイルを作成 (不整合な列数のwarningが出る)
+        test_file = self.data_dir / "test_warning_strict.csv"
+        # ファイルサイズチェックをクリアするため、十分なデータを追加
+        content = "col1,col2,col3\n" + "val1,val2\n" * 10  # 100バイト以上になるように
+        test_file.write_bytes(content.encode("shift_jis"))
+
+        # strictモード (strict=True)
+        validator = DataValidator(strict_mode=True)
+        result = validator.validate_file(test_file)
+
+        # warningsは収集される
+        self.assertTrue(len(result["warnings"]) > 0, "warnings should be collected")
+        # strictモードではwarningsでinvalidになる
+        self.assertFalse(result["valid"], "valid should be False in strict mode with warnings")
+        # has_warningsがTrueになる
+        self.assertTrue(validator.has_warnings, "has_warnings should be True")
+
 
 class TestMarkdownEscaping(unittest.TestCase):
     """Markdown特殊文字のエスケープテスト"""


### PR DESCRIPTION
## 概要
issue #218 を解決: `scripts/validate_data.py` の `DataValidator.validate_file()` で、警告が `valid=False` のときしか集計されず、正常ファイルの警告がレポートに出ない問題を修正しました。

## 問題
- `size_result` / `csv_result` の warnings が `not valid` の条件内でしか追加されない
- `has_warnings` が `strict_mode` 時のみ true になる
- 結果として、正常ファイルの警告が把握できない
- `--strict` モードの挙動も弱くなる

## 解決策
1. **warnings を valid に関係なく常に収集**
   - `size_result` の warnings を if 文の外に移動 (line 87)
   - `csv_result` の warnings を if 文の外に移動 (line 106)
   
2. **has_warnings の設定を strict モードと独立化**
   - warnings があれば常に `has_warnings = True` に設定 (line 127)
   - strict モード時のみ warnings で invalid にする (line 129-130)

## 変更内容

### scripts/validate_data.py
```python
# Before (line 84-86)
if not size_result["valid"]:
    result["errors"].extend(size_result.get("errors", []))
    result["warnings"].extend(size_result.get("warnings", []))  # valid=Falseの時のみ

# After (line 84-87)
if not size_result["valid"]:
    result["errors"].extend(size_result.get("errors", []))
# warningsはvalidに関係なく常に収集
result["warnings"].extend(size_result.get("warnings", []))
```

```python
# Before (line 121-126)
if result["errors"]:
    result["valid"] = False
    self.has_errors = True
elif result["warnings"] and self.strict_mode:  # strictモード時のみ
    result["valid"] = False
    self.has_warnings = True

# After (line 123-130)
if result["errors"]:
    result["valid"] = False
    self.has_errors = True
# warningsは常に記録し、strictモード時はinvalidにする
if result["warnings"]:
    self.has_warnings = True
    if self.strict_mode:
        result["valid"] = False
```

## テスト結果
```bash
# 新しいテスト
✅ test_warnings_collected_even_when_valid: CSVフォーマットがvalidでもwarningsが収集されることを確認
✅ test_warnings_make_invalid_in_strict_mode: strictモード時にwarningsでinvalidになることを確認

# 全テスト
✅ 13 passed in 0.15s
```

## 影響範囲
- **通常モード**: warnings が常にレポートに出るようになる（改善）
- **strict モード**: 挙動は変わらず（warnings で invalid になる）
- **既存テスト**: 全て成功（リグレッションなし）

## 受け入れ条件
- ✅ warnings が常に `result["warnings"]` に残る
- ✅ strict モード時は warnings があるだけで invalid になる
- ✅ `has_warnings` が warnings の有無を正しく反映する
- ✅ テスト追加: warning 出力の回帰テスト

Closes #218

🤖 Generated with [Claude Code](https://claude.com/claude-code)