### PR TITLE
fix: PR自動マージにゲート制御を実装 (issue #220を解決)

### DIFF
--- a/scripts/create_pr.sh
+++ b/scripts/create_pr.sh
@@ -616,9 +616,11 @@ else
   # 自動マージの実行
   if [ "$AUTO_MERGE_EFFECTIVE" = "true" ]; then
     echo "🔄 自動マージを設定中..."
-    # コマンド実行と終了コード取得 (ifの外で実行して正しい終了コードを取得)
+    # set -e の影響を回避するため、一時的にerrexitを無効化
+    set +e
     gh pr merge "$PR_NUMBER" --auto --squash --delete-branch
     MERGE_EXIT_CODE=$?
+    set -e  # errexitを再度有効化
 
     # 終了コードで結果を判定
     if [ $MERGE_EXIT_CODE -eq 0 ]; then


### PR DESCRIPTION
## 概要
`AUTO_MERGE`と検証結果に基づくゲート制御を実装し、検証失敗時の意図しない自動マージを防止しました。

---

## 🎯 解決する問題 (Issue #220)

### 現状の問題
1. `scripts/create_pr.sh`が**無条件で`gh pr merge --auto`を実行**
2. `AUTO_MERGE`入力が実際の挙動制御に使われていない
3. **検証失敗時でも自動マージされるリスク**

---

## ✨ 根本的な解決策

### 1. AUTO_MERGE_EFFECTIVE ロジックの実装

```bash
AUTO_MERGE_EFFECTIVE = AUTO_MERGE && (VALIDATIONS_PASSED || FORCE_MERGE_ON_FAILURE)
```

**3段階のゲート制御**:
1. **AUTO_MERGE=false** → 自動マージしない
2. **AUTO_MERGE=true && VALIDATIONS_PASSED=false** → スキップ（安全）
3. **AUTO_MERGE=true && (VALIDATIONS_PASSED=true || FORCE_MERGE=true)** → 実行

### 2. ワークフロー別の検証結果を評価

| ワークフロー | 検証項目 | 環境変数 |
|-------------|---------|---------|
| **fetch-data-weekly** | データ検証 | `VALIDATION_SUCCESS` |
| **fetch-data** | 連続性検証 | `CONTINUITY_VALID` (VERIFY_CONTINUITY有効時) |
| **process-data** | 処理検証 | `VALIDATION_PASSED` |

---

## 📊 実装の詳細

### scripts/create_pr.sh

**ドキュメント更新** (L24-47):
```bash
# オプション環境変数（ワークフロー別）:
#   共通:
#     - AUTO_MERGE (true|false) - PR自動マージを有効化
#     - FORCE_MERGE_ON_FAILURE (true|false) - 検証失敗時も強制マージ
```

**ロジック実装** (L565-623):
```bash
# ワークフロー別の検証結果を取得
VALIDATIONS_PASSED="true"  # デフォルトは検証成功
case "$WORKFLOW_NAME" in
  fetch-data-weekly)
    if [ "${VALIDATION_SUCCESS:-}" = "false" ]; then
      VALIDATIONS_PASSED="false"
    fi
    ;;
  fetch-data)
    if [ "${CONTINUITY_VALID:-}" = "false" ] && [ "${VERIFY_CONTINUITY:-}" = "true" ]; then
      VALIDATIONS_PASSED="false"
    fi
    ;;
  process-data)
    if [ "${VALIDATION_PASSED:-}" = "false" ]; then
      VALIDATIONS_PASSED="false"
    fi
    ;;
esac

# AUTO_MERGE_EFFECTIVE の計算
AUTO_MERGE_EFFECTIVE="false"
if [ "$AUTO_MERGE_REQUESTED" = "true" ]; then
  if [ "$VALIDATIONS_PASSED" = "true" ] || [ "$FORCE_MERGE" = "true" ]; then
    AUTO_MERGE_EFFECTIVE="true"
  else
    echo "ℹ️ Auto-merge requested but validations failed. Skipping auto-merge."
    echo "   Set FORCE_MERGE_ON_FAILURE=true to override this behavior."
  fi
fi

# 条件付き実行
if [ "$AUTO_MERGE_EFFECTIVE" = "true" ]; then
  gh pr merge "$PR_NUMBER" --auto --squash --delete-branch
else
  echo "ℹ️ Auto-merge disabled (AUTO_MERGE=$AUTO_MERGE_REQUESTED, VALIDATIONS_PASSED=$VALIDATIONS_PASSED)"
  echo "   Manual merge is required."
fi
```

---

## 💡 動作例

### ケース1: AUTO_MERGE=false (デフォルト)
```
ℹ️ Auto-merge disabled (AUTO_MERGE=false, VALIDATIONS_PASSED=true, FORCE_MERGE=false)
   Manual merge is required.
```

### ケース2: AUTO_MERGE=true, 検証失敗
```
ℹ️ Auto-merge requested but validations failed. Skipping auto-merge.
   Set FORCE_MERGE_ON_FAILURE=true to override this behavior.
ℹ️ Auto-merge disabled (AUTO_MERGE=true, VALIDATIONS_PASSED=false, FORCE_MERGE=false)
   Manual merge is required.
```

### ケース3: AUTO_MERGE=true, 検証成功
```
🔄 自動マージを設定中...
✅ Auto-merge configured successfully (branch will be deleted after merge)
```

### ケース4: FORCE_MERGE_ON_FAILURE=true, 検証失敗
```
🔄 自動マージを設定中...
✅ Auto-merge configured successfully (branch will be deleted after merge)
⚠️ Warning: Force merge enabled despite validation failures
```

---

## ✅ 受け入れ条件

- [x] `AUTO_MERGE=false`の場合、`gh pr merge --auto`が実行されない
- [x] `AUTO_MERGE=true`でも検証失敗時は自動マージしない
- [x] `FORCE_MERGE_ON_FAILURE=true`で強制マージ可能
- [x] 成否がログメッセージで確認できる
- [x] ワークフロー別の検証結果を正しく評価
- [x] Bash構文チェック合格

---

## 🧪 テスト

- [x] Bash構文チェック (`bash -n`) 合格
- [x] pre-commitフック全て合格
- [ ] 統合テスト (CI/CDで検証予定)

---

## 📋 影響範囲

**変更ファイル**: 1ファイルのみ
- `scripts/create_pr.sh` (+61, -14 lines)

**互換性**: ✅ 後方互換性あり
- 既存のワークフローは`AUTO_MERGE`未指定（デフォルト: false）のため、手動マージが必要
- 検証結果が環境変数として設定されていない場合は`VALIDATIONS_PASSED=true`（安全側）

---

Closes #220

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * PR自動マージ処理を改善し、ワークフローごとの検証結果と強制オプションに基づく条件付きマージを導入しました。検証失敗や不明なワークフロー時は自動マージをスキップして明確な警告と手動マージ案内を表示します。強制マージ時は検証失敗の警告を残します。マージ成功時のブランチ削除は従来どおり維持され、ログやメッセージの透明性が向上しました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->