### PR TITLE
fix: fetch失敗のゲート制御とサマリー可視化を追加

### DIFF
--- a/.github/workflows/_fetch-data-common.yml
+++ b/.github/workflows/_fetch-data-common.yml
@@ -283,12 +283,20 @@ jobs:
           echo "Executing: ${FETCH_CMD[@]}"
 
           # メインスクリプトの実行
-          if "${FETCH_CMD[@]}" 2>&1 | tee "data/logs/console_${LOG_PREFIX}_${FETCH_TIMESTAMP}.log"; then
-            FETCH_EXIT_CODE=0
+          # NOTE:
+          # - pipefail: パイプライン全体の失敗を検出
+          # - PIPESTATUS: 各コマンドの終了コード配列
+          # PIPESTATUSは次のコマンド実行で上書きされるため、実行直後に退避する
+          set +e
+          "${FETCH_CMD[@]}" 2>&1 | tee "data/logs/console_${LOG_PREFIX}_${FETCH_TIMESTAMP}.log"
+          PIPE_EXIT_CODES=("${PIPESTATUS[@]}")
+          set -e
+
+          FETCH_EXIT_CODE="${PIPE_EXIT_CODES[0]}"
+          if [ "${FETCH_EXIT_CODE}" -eq 0 ]; then
             FETCH_STATUS="success"
             echo "✅ データ取得: 成功"
           else
-            FETCH_EXIT_CODE=${PIPESTATUS[0]}
             FETCH_STATUS="failed"
             echo "❌ データ取得: 失敗 (exit code: ${FETCH_EXIT_CODE})"
           fi


### PR DESCRIPTION
## Summary
- add explicit fetch result handling in `.github/workflows/_fetch-data-common.yml`
- add `Fetch result gate` step to enforce continue/fail policy using `continue_on_failure` and `force_merge_on_failure`
- add summary diagnostics for `FETCH_STATUS`, `FETCH_RESULT`, and `FETCH_CONTINUED_REASON`

## Why
- issue #297 で指摘された通り、`FETCH_RESULT` は保存のみで実際のゲート制御に使われていませんでした
- fetch失敗時の継続/停止ポリシーを process step と整合させ、運用時の判断根拠をサマリーに明示する必要がありました

## Changes
- `Fetch epidemic data` step
  - explicitly enable `set -o pipefail`
  - persist `FETCH_RESULT` and `FETCH_STATUS` for both success/failure paths
  - initialize `FETCH_CONTINUED_REASON=none`
- new `Fetch result gate` step
  - if fetch failed and both flags are false: `exit 1`
  - otherwise continue with warning and persist continuation reason
- `Generate summary` step
  - include fetch status, exit code, and continuation reason

## Validation
- pre-commit checks on commit passed (including YAML syntax check)
- verified workflow YAML parse locally

Closes #297


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **改善**
  * データ取得ステップのエラーハンドリングを強化し、パイプライン内の個別コマンド終了コードを正確に扱うようにしました。
  * 取得結果に関する新しい環境変数（取得結果、取得ステータス、継続理由）を追加し後続ステップで参照可能にしました。
  * 取得失敗時の動作を制御する「フェッチ結果ゲート」を導入し、継続・停止の挙動を明確化しました。
  * ワークフローの出力に取得結果の詳細（ステータス、終了コード、継続理由）を追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->