### PR TITLE
fix(charts): 乖離率グラフが全疾患baseline以下のとき空になる問題を修正

### DIFF
--- a/scripts/generate_charts.py
+++ b/scripts/generate_charts.py
@@ -620,7 +620,8 @@ def select_top_deviation_diseases(
         代表乖離率値は符号付き:
           - 通常パス: 期間内の最大正乖離率 (常に正)
           - フォールバック: 期間内で絶対値が最大の乖離率 (負になりうる)
-        fallback_used が True のとき、正乖離が一つも存在せず絶対値で選定したことを示す
+        fallback_used が True のとき、正乖離が一つも存在せず絶対値で選定したことを示す。
+        入力 deviation_rates が空、または全疾患が None のみの場合は ([], True) を返す。
     """
     primary_scores: dict[str, float] = {}
     fallback_scores: dict[str, float] = {}
@@ -631,6 +632,7 @@ def select_top_deviation_diseases(
             continue
         # 絶対値最大の値を符号を保ったまま記録 (= 期間内で最も極端な乖離)
         fallback_scores[disease] = max(non_null_values, key=abs)
+        # ちょうど baseline (v == 0) はフォールバック対象 ("正乖離なし" 扱い)
         positive_values = [v for v in non_null_values if v > 0]
         if positive_values:
             primary_scores[disease] = max(positive_values)

--- a/scripts/generate_charts.py
+++ b/scripts/generate_charts.py
@@ -18,6 +18,7 @@ import csv
 import hashlib
 import time
 from collections import defaultdict
+from collections.abc import Mapping
 from functools import lru_cache
 from pathlib import Path
 
@@ -596,7 +597,7 @@ def calculate_deviation_rate(
 
 
 def select_top_deviation_diseases(
-    deviation_rates: dict[str, dict[int, float | None]], top_n: int = 5
+    deviation_rates: Mapping[str, Mapping[int, float | None]], top_n: int = 5
 ) -> tuple[list[tuple[str, float]], bool]:
     """乖離率グラフ用のトップN疾患を選定 (CDC流: 期間全体での最大正乖離)
 
@@ -612,7 +613,9 @@ def select_top_deviation_diseases(
 
     Args:
         deviation_rates: 疾患名 -> {期間番号: 乖離率(%) または None}
-            None は乖離率が計算できなかった期間を表し、選定から除外される
+            None は乖離率が計算できなかった期間を表し、選定から除外される。
+            型は Mapping (共変) で受けるため、calculate_deviation_rate() の
+            戻り値 dict[str, dict[int, float]] (None を含まない) もそのまま渡せる。
         top_n: 表示する疾患数
 
     Returns:

--- a/scripts/generate_charts.py
+++ b/scripts/generate_charts.py
@@ -596,7 +596,7 @@ def calculate_deviation_rate(
 
 
 def select_top_deviation_diseases(
-    deviation_rates: dict[str, dict[int, float]], top_n: int = 5
+    deviation_rates: dict[str, dict[int, float | None]], top_n: int = 5
 ) -> tuple[list[tuple[str, float]], bool]:
     """乖離率グラフ用のトップN疾患を選定 (CDC流: 期間全体での最大正乖離)
 
@@ -607,35 +607,40 @@ def select_top_deviation_diseases(
     選定ロジック:
     1. 期間内のいずれかで baseline を超えた疾患があれば、その最大正乖離値で
        降順ソートしてトップN件を選ぶ (流行検知の本来の意図を維持)
-    2. 期間中ずっと baseline 以下の場合は、絶対値の最大乖離で降順ソートして
-       トップN件を選ぶ (空グラフ回避のフォールバック)
+    2. 期間中ずっと baseline 以下の場合は、絶対値最大の乖離率(符号付き)で
+       降順ソートしてトップN件を選ぶ (空グラフ回避のフォールバック)
 
     Args:
-        deviation_rates: 疾患名 -> {期間番号: 乖離率(%)}
+        deviation_rates: 疾患名 -> {期間番号: 乖離率(%) または None}
+            None は乖離率が計算できなかった期間を表し、選定から除外される
         top_n: 表示する疾患数
 
     Returns:
         ([(疾患名, 代表乖離率値), ...], fallback_used)
+        代表乖離率値は符号付き:
+          - 通常パス: 期間内の最大正乖離率 (常に正)
+          - フォールバック: 期間内で絶対値が最大の乖離率 (負になりうる)
         fallback_used が True のとき、正乖離が一つも存在せず絶対値で選定したことを示す
     """
-    period_max_positive: dict[str, float] = {}
-    period_max_abs: dict[str, float] = {}
+    primary_scores: dict[str, float] = {}
+    fallback_scores: dict[str, float] = {}
 
     for disease, periods in deviation_rates.items():
         non_null_values = [v for v in periods.values() if v is not None]
         if not non_null_values:
             continue
-        period_max_abs[disease] = max(abs(v) for v in non_null_values)
+        # 絶対値最大の値を符号を保ったまま記録 (= 期間内で最も極端な乖離)
+        fallback_scores[disease] = max(non_null_values, key=abs)
         positive_values = [v for v in non_null_values if v > 0]
         if positive_values:
-            period_max_positive[disease] = max(positive_values)
+            primary_scores[disease] = max(positive_values)
 
-    if period_max_positive:
-        ranked = sorted(period_max_positive.items(), key=lambda x: x[1], reverse=True)
+    if primary_scores:
+        ranked = sorted(primary_scores.items(), key=lambda x: x[1], reverse=True)
         return ranked[:top_n], False
 
-    ranked_abs = sorted(period_max_abs.items(), key=lambda x: x[1], reverse=True)
-    return ranked_abs[:top_n], True
+    ranked_fallback = sorted(fallback_scores.items(), key=lambda x: abs(x[1]), reverse=True)
+    return ranked_fallback[:top_n], True
 
 
 def _format_period_label(min_period: int, max_period: int, period_type: str) -> str:
@@ -942,9 +947,9 @@ def generate_deviation_chart(
 
     # データソースと注釈 (下側の確保したスペースに配置)
     if fallback_used:
-        note_text = "※ 期間中ベースラインを超える疾患なし — 参考として乖離絶対値の大きい疾患を最大5つ表示"
+        note_text = f"※ 期間中ベースラインを超える疾患なし — 参考として乖離絶対値の大きい疾患を最大{top_n}つ表示"
     else:
-        note_text = "※ 期間中の最大正乖離(流行兆候)が大きい疾患を最大5つ表示"
+        note_text = f"※ 期間中の最大正乖離(流行兆候)が大きい疾患を最大{top_n}つ表示"
     footer_text = f"{note_text}\n{data_source}"
     if JAPANESE_FONT:
         # FontPropertiesをサイズ指定でcopy (fontsize上書き問題を回避)

--- a/scripts/generate_charts.py
+++ b/scripts/generate_charts.py
@@ -595,6 +595,49 @@ def calculate_deviation_rate(
     return deviation_rates
 
 
+def select_top_deviation_diseases(
+    deviation_rates: dict[str, dict[int, float]], top_n: int = 5
+) -> tuple[list[tuple[str, float]], bool]:
+    """乖離率グラフ用のトップN疾患を選定 (CDC流: 期間全体での最大正乖離)
+
+    最新1期間だけで判定すると、期間内で大きく流行した疾患も
+    現在値がbaseline以下まで戻ると消えてしまう。CDC FluView同様に
+    期間全体を視野に入れて選定する。
+
+    選定ロジック:
+    1. 期間内のいずれかで baseline を超えた疾患があれば、その最大正乖離値で
+       降順ソートしてトップN件を選ぶ (流行検知の本来の意図を維持)
+    2. 期間中ずっと baseline 以下の場合は、絶対値の最大乖離で降順ソートして
+       トップN件を選ぶ (空グラフ回避のフォールバック)
+
+    Args:
+        deviation_rates: 疾患名 -> {期間番号: 乖離率(%)}
+        top_n: 表示する疾患数
+
+    Returns:
+        ([(疾患名, 代表乖離率値), ...], fallback_used)
+        fallback_used が True のとき、正乖離が一つも存在せず絶対値で選定したことを示す
+    """
+    period_max_positive: dict[str, float] = {}
+    period_max_abs: dict[str, float] = {}
+
+    for disease, periods in deviation_rates.items():
+        non_null_values = [v for v in periods.values() if v is not None]
+        if not non_null_values:
+            continue
+        period_max_abs[disease] = max(abs(v) for v in non_null_values)
+        positive_values = [v for v in non_null_values if v > 0]
+        if positive_values:
+            period_max_positive[disease] = max(positive_values)
+
+    if period_max_positive:
+        ranked = sorted(period_max_positive.items(), key=lambda x: x[1], reverse=True)
+        return ranked[:top_n], False
+
+    ranked_abs = sorted(period_max_abs.items(), key=lambda x: x[1], reverse=True)
+    return ranked_abs[:top_n], True
+
+
 def _format_period_label(min_period: int, max_period: int, period_type: str) -> str:
     """期間ラベルを生成 (X軸用)
 
@@ -849,12 +892,10 @@ def generate_deviation_chart(
     # 日本語フォントを初期化 (遅延評価)
     JAPANESE_FONT = get_japanese_font()
 
-    # 最新期間でプラス方向(流行)の乖離率が大きい疾患のトップNを選択(CDCスタイル)
-    latest_period = max(all_periods)
-    latest_deviation_rates = {disease: periods.get(latest_period, 0) for disease, periods in deviation_rates.items()}
-    # プラス方向(流行)のみを抽出してソート
-    positive_deviations = {k: v for k, v in latest_deviation_rates.items() if v > 0}
-    top_diseases = sorted(positive_deviations.items(), key=lambda x: x[1], reverse=True)[:top_n]
+    # 期間全体で baseline を超えた疾患 (最大正乖離) を優先選定。
+    # 最新期間1点だけで判定すると、期間内で流行した疾患が現在 baseline 以下に
+    # 戻った瞬間に全て消えて空グラフになるため (CDC FluView 同様 full-season 方式)。
+    top_diseases, fallback_used = select_top_deviation_diseases(deviation_rates, top_n=top_n)
 
     # グラフ作成 (800x500px固定サイズ)
     fig, ax = plt.subplots(figsize=(8, 5))
@@ -900,7 +941,10 @@ def generate_deviation_chart(
     plt.tight_layout(rect=(0, 0.06, 1, 0.98))
 
     # データソースと注釈 (下側の確保したスペースに配置)
-    note_text = "※ 季節性ベースラインより高い(プラス乖離)疾患を最大5つ表示"
+    if fallback_used:
+        note_text = "※ 期間中ベースラインを超える疾患なし — 参考として乖離絶対値の大きい疾患を最大5つ表示"
+    else:
+        note_text = "※ 期間中の最大正乖離(流行兆候)が大きい疾患を最大5つ表示"
     footer_text = f"{note_text}\n{data_source}"
     if JAPANESE_FONT:
         # FontPropertiesをサイズ指定でcopy (fontsize上書き問題を回避)

--- a/tests/test_generate_charts.py
+++ b/tests/test_generate_charts.py
@@ -337,16 +337,19 @@ class TestSelectTopDeviationDiseases:
         assert top == []
         assert fallback is True
 
-    def test_fallback_preserves_sign_for_max_abs(self):
-        """フォールバック時、絶対値最大の値は符号を保つ (正負混在で常に負方向の最大値が返るわけではない)"""
-        # 期間内: [+30, -50] → 絶対値最大は -50 (符号付きで返る)
-        # ただし +30 が存在するため通常パス (primary_scores) が発動し fallback にはならない
+    def test_fallback_does_not_activate_when_positive_deviations_exist(self):
+        """正乖離が一つでも存在すればフォールバックは発動しない (正負混在ケース)
+
+        期間内: [+30, -50] → 絶対値最大は -50 だが、+30 が存在するため
+        通常パス (primary_scores) が発動し、fallback_used=False が返る。
+        通常パスのスコアは max(positive_values) = 30.0。
+        """
         deviation_rates = {
             "疾患A": {202501: 30.0, 202502: -50.0},
         }
         top, fallback = select_top_deviation_diseases(deviation_rates, top_n=5)
-        assert fallback is False  # 正乖離があるので通常パス
-        assert top[0][1] == 30.0  # 通常パスは max(positive_values)
+        assert fallback is False
+        assert top[0][1] == 30.0
 
     def test_fallback_with_mixed_negative_magnitudes(self):
         """フォールバックで複数の負乖離疾患を絶対値順に並べ、符号付きで返す"""

--- a/tests/test_generate_charts.py
+++ b/tests/test_generate_charts.py
@@ -277,7 +277,10 @@ class TestSelectTopDeviationDiseases:
         assert [d for d, _ in top] == ["疾患10", "疾患9", "疾患8"]
 
     def test_fallback_when_all_below_baseline(self):
-        """期間中ずっと baseline 以下のとき、絶対値TopNにフォールバック"""
+        """期間中ずっと baseline 以下のとき、絶対値TopNにフォールバック
+
+        ソート順は絶対値降順だが、戻り値は符号を保つ。
+        """
         deviation_rates = {
             "疾患A": {202601: -100.0, 202602: -50.0},
             "疾患B": {202601: -10.0, 202602: -20.0},
@@ -287,9 +290,12 @@ class TestSelectTopDeviationDiseases:
         top, fallback = select_top_deviation_diseases(deviation_rates, top_n=5)
 
         assert fallback is True
-        # 絶対値降順: A(100) > B(20) > C(0)
+        # 絶対値降順: |A|=100 > |B|=20 > |C|=0
         assert [d for d, _ in top] == ["疾患A", "疾患B", "疾患C"]
-        assert top[0][1] == 100.0
+        # 値は符号付き
+        assert top[0][1] == -100.0
+        assert top[1][1] == -20.0
+        assert top[2][1] == 0.0
 
     def test_zero_only_data_returns_fallback(self):
         """全疾患の値が 0 のみのとき、フォールバック経由で 0 値が返る"""
@@ -330,6 +336,28 @@ class TestSelectTopDeviationDiseases:
 
         assert top == []
         assert fallback is True
+
+    def test_fallback_preserves_sign_for_max_abs(self):
+        """フォールバック時、絶対値最大の値は符号を保つ (正負混在で常に負方向の最大値が返るわけではない)"""
+        # 期間内: [+30, -50] → 絶対値最大は -50 (符号付きで返る)
+        # ただし +30 が存在するため通常パス (primary_scores) が発動し fallback にはならない
+        deviation_rates = {
+            "疾患A": {202501: 30.0, 202502: -50.0},
+        }
+        top, fallback = select_top_deviation_diseases(deviation_rates, top_n=5)
+        assert fallback is False  # 正乖離があるので通常パス
+        assert top[0][1] == 30.0  # 通常パスは max(positive_values)
+
+    def test_fallback_with_mixed_negative_magnitudes(self):
+        """フォールバックで複数の負乖離疾患を絶対値順に並べ、符号付きで返す"""
+        deviation_rates = {
+            "疾患A": {202501: -5.0, 202502: -3.0},
+            "疾患B": {202501: -50.0},
+        }
+        top, fallback = select_top_deviation_diseases(deviation_rates, top_n=5)
+        assert fallback is True
+        assert top[0] == ("疾患B", -50.0)
+        assert top[1] == ("疾患A", -5.0)
 
 
 class TestParseSentinelWeeklyGender:

--- a/tests/test_generate_charts.py
+++ b/tests/test_generate_charts.py
@@ -21,6 +21,7 @@ from scripts.generate_charts import (
     parse_notifiable_weekly,
     parse_period_from_filename,
     parse_sentinel_weekly_gender,
+    select_top_deviation_diseases,
 )
 
 
@@ -237,6 +238,98 @@ class TestCalculateDeviationRate:
 
         # 疾患がベースラインに存在しない場合はスキップ
         assert "新型疾患" not in rates
+
+
+class TestSelectTopDeviationDiseases:
+    """select_top_deviation_diseases()関数のテスト
+
+    乖離率グラフ用の TopN 選定ロジック:
+    - 期間内のいずれかで baseline を超えた疾患があれば、最大正乖離の降順で TopN
+    - 全期間 baseline 以下なら、絶対値最大乖離の降順で TopN (空グラフ回避フォールバック)
+    """
+
+    def test_positive_deviation_uses_window_max(self):
+        """期間内のどこかで正乖離があれば、最新が負でも選定される"""
+        # 疾患Aは最新負だが期間内で +1900% のピーク, Bは最新正だが小さい
+        deviation_rates = {
+            "疾患A": {202508: 1900.0, 202604: -100.0},
+            "疾患B": {202508: 5.0, 202604: 10.0},
+        }
+
+        top, fallback = select_top_deviation_diseases(deviation_rates, top_n=5)
+
+        assert fallback is False
+        # Aの代表値は期間内最大の1900
+        assert top[0][0] == "疾患A"
+        assert top[0][1] == 1900.0
+        assert top[1][0] == "疾患B"
+        assert top[1][1] == 10.0
+
+    def test_top_n_respected(self):
+        """top_n を超える結果は返さない"""
+        deviation_rates = {f"疾患{i}": {202501: float(i)} for i in range(1, 11)}
+
+        top, fallback = select_top_deviation_diseases(deviation_rates, top_n=3)
+
+        assert fallback is False
+        assert len(top) == 3
+        # 上位3つは 10, 9, 8
+        assert [d for d, _ in top] == ["疾患10", "疾患9", "疾患8"]
+
+    def test_fallback_when_all_below_baseline(self):
+        """期間中ずっと baseline 以下のとき、絶対値TopNにフォールバック"""
+        deviation_rates = {
+            "疾患A": {202601: -100.0, 202602: -50.0},
+            "疾患B": {202601: -10.0, 202602: -20.0},
+            "疾患C": {202601: 0.0},
+        }
+
+        top, fallback = select_top_deviation_diseases(deviation_rates, top_n=5)
+
+        assert fallback is True
+        # 絶対値降順: A(100) > B(20) > C(0)
+        assert [d for d, _ in top] == ["疾患A", "疾患B", "疾患C"]
+        assert top[0][1] == 100.0
+
+    def test_zero_only_data_returns_fallback(self):
+        """全疾患の値が 0 のみのとき、フォールバック経由で 0 値が返る"""
+        deviation_rates = {"疾患A": {202501: 0.0}}
+
+        top, fallback = select_top_deviation_diseases(deviation_rates, top_n=5)
+
+        assert fallback is True
+        assert top == [("疾患A", 0.0)]
+
+    def test_disease_with_no_values_excluded(self):
+        """値が一つもない疾患は選定対象外"""
+        deviation_rates = {
+            "疾患A": {},
+            "疾患B": {202501: 50.0},
+        }
+
+        top, fallback = select_top_deviation_diseases(deviation_rates, top_n=5)
+
+        assert fallback is False
+        assert [d for d, _ in top] == ["疾患B"]
+
+    def test_none_values_skipped(self):
+        """None 値は除外し、有効値のみで判定する"""
+        deviation_rates = {
+            "疾患A": {202501: None, 202502: 25.0},
+            "疾患B": {202501: None, 202502: None},  # 有効値なし → 除外
+        }
+
+        top, fallback = select_top_deviation_diseases(deviation_rates, top_n=5)
+
+        assert fallback is False
+        assert [d for d, _ in top] == ["疾患A"]
+
+    def test_empty_input(self):
+        """空入力は空リスト + fallback=True を返す (空フィルタの後は常にフォールバック判定)"""
+        top, fallback = select_top_deviation_diseases({}, top_n=5)
+
+        assert top == []
+        assert fallback is True
 
 
 class TestParseSentinelWeeklyGender:


### PR DESCRIPTION
## Summary

- **問題**: `docs/images/sentinel_monthly_deviation.png` が完全に空 (折れ線ゼロ本) になっていた。最新期間1点だけで「正乖離 (流行兆候) を持つ疾患」を絞り込む実装だったため、2026年4月時点で全9疾患が baseline 以下となり Top N 選定で 0 件 → 描画する線がゼロ、という状態。
- **修正方針**: CDC FluView 同様の full-season 表示に変更。期間 (直近12ヶ月/52週) 全体での **最大正乖離** で Top N を選定し、もし期間中ずっと baseline 以下なら絶対値最大乖離で Top N にフォールバックして空グラフを防止する。
- **副次効果**: 過去に大きく流行した疾患 (例: 薬剤耐性緑膿菌感染症の 2025年8月 +1900%) が、現在値が baseline 以下に戻っても凡例に残り、流行→回帰のトレンドを通年で観察可能になる。

## 変更点

- `scripts/generate_charts.py`
  - `select_top_deviation_diseases()` をテスト可能なヘルパー関数として新設
  - `generate_deviation_chart()` 内の選定ロジックを新関数に置き換え
  - フォールバック時はフッター注釈を切り替えて状況を明示
- `tests/test_generate_charts.py`
  - `TestSelectTopDeviationDiseases` クラスを追加 (7 ケース)

## 検証結果

- `uv run pytest tests/test_generate_charts.py`: 32件 全PASS
- 全体テスト: 619件 全PASS、`src/` カバレッジ 100% 維持
- 新関数 `select_top_deviation_diseases()` は branch coverage 含め 100% 網羅
- pre-commit (black/ruff/mypy/RUF002 等) PASS
- 実データで再生成し、月次・週次の3グラフすべて空にならず正常描画されることを目視確認済み

## Test plan

- [ ] CI (lint/test/codecov) すべて green
- [ ] マージ後の次回データ更新ワークフローで `sentinel_monthly_deviation.png` が空でないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * グラフの「トップN疾患」選定ロジックを改善：期間全体の最大正乖離に基づき順位付け
  * 正乖離がない場合は、絶対値最大の乖離（符号を保持）を代替選定し、フォールバック判定を返す
  * フォールバック時と通常時でグラフ下部の注釈表示を切替

* **テスト**
  * 上記選定ロジックに関する包括的なテストを追加（空入力・欠損値・全ゼロ・負の最大値等を検証）

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kambarakun/fetch-tokyo-idsc-github-actions/pull/440)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->