### PR TITLE
ci(security): test.yml の GITHUB_TOKEN 権限を contents:read に最小化

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,13 @@ on:
     branches: [main]
   workflow_dispatch:
 
+# 最小権限原則 (issue #299): テスト/lintはコミット・PR操作を行わないため read-only で十分。
+# - actions/checkout: contents: read
+# - codecov-action: CODECOV_TOKEN (リポジトリシークレット) を使用するため GITHUB_TOKEN 追加権限不要
+# - actions/upload-artifact: GITHUB_TOKEN を使用しない (Actions API 側で別管理)
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

issue #299 対応。`.github/workflows/test.yml` に `permissions:` が未定義で、`GITHUB_TOKEN` の権限がデフォルト依存となっていた状態を解消する。最小権限原則 (least privilege) に従い、明示的に `contents: read` に絞った。

## 権限要件の検証

各stepが必要とする権限を確認:

| step | 必要権限 |
|------|---------|
| `actions/checkout@v4` | `contents: read` |
| `astral-sh/setup-uv@v4` | なし |
| `uv python install` / `uv sync` / `pytest` | なし |
| `codecov/codecov-action@v5` | `GITHUB_TOKEN`不要 (`CODECOV_TOKEN` を使用) |
| `actions/upload-artifact@v4` | `GITHUB_TOKEN`不要 (Actions API側で別管理) |
| `py_compile` / `ruff` / `black` / `isort` / `mypy` | なし |

→ `contents: read` で十分。

## 既存workflowとの整合性

| Workflow | permissions |
|----------|-------------|
| `fetch-data*.yml` | `contents:write` `issues:write` `pull-requests:write` (PR作成・コミット) |
| `process-data.yml` | 同上 |
| `migrate-metadata.yml` | `contents:write` `pull-requests:write` |
| **`test.yml` (本変更)** | **`contents:read`** |

データ更新系は write 権限が必要ですが、test/lint は read のみで動作するため最小化。

## ベストプラクティス出典

- [GitHub Docs: Modifying permissions for GITHUB_TOKEN](https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token)
- [GitHub Docs: Secure use reference](https://docs.github.com/en/actions/reference/security/secure-use)

## Test plan

- [ ] CI (lint/test/codecov) すべて green
- [ ] codecov upload が引き続き成功する (CODECOV_TOKEN secret 経由)

Closes #299

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores

* ワークフロー設定のセキュリティ強化により、テスト実行時の権限を最小化しました。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kambarakun/fetch-tokyo-idsc-github-actions/pull/443)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->