### PR TITLE
docs(readme): リファレンス情報4セクションを <details> 折りたたみで READMEを47%圧縮

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,6 +279,9 @@ sentinel_weekly_medical_district_2025_22.csv (不整合: 11件)
 | **sentinel_monthly_health_center**    | 定点     | 月次 | 保健所別         | 月別定点あたり患者報告数(保健所別)         |
 | **sentinel_monthly_medical_district** | 定点     | 月次 | 二次保健医療圏別 | 月別定点あたり患者報告数(二次保健医療圏別) |
 
+<details>
+<summary>📁 ディレクトリ構造 / ファイル命名規則 / メタデータスキーマ v1.3.0 (クリックして展開)</summary>
+
 #### データディレクトリ構造
 
 ```text
@@ -402,9 +405,14 @@ data/
 
 検証スキーマの詳細は [`CLAUDE.md`](CLAUDE.md#83-メタデータスキーマ-v130) を参照してください。
 
+</details>
+
 ### 🔄 データ処理の詳細
 
 `data/processed/` ディレクトリには、`data/raw/` の生データを以下の処理フローで変換したファイルが格納されます。
+
+<details>
+<summary>🔄 処理フロー図 (Mermaid) / ステップ詳細 / 注意事項 (クリックして展開)</summary>
 
 #### 処理フロー図
 
@@ -500,6 +508,8 @@ flowchart TD
    - 例: ARIの「2歳」データが必要な場合 → 「1歳 (=1~4歳)」のデータを参照
 3. **行をフィルタリング**: `*`を含む行を除外して分析
 
+</details>
+
 ## 🔄 GitHub Actionsワークフロー
 
 ### 🤖 自動実行ワークフロー
@@ -525,6 +535,9 @@ flowchart TD
 3. **"Run workflow"** をクリック
 4. 必要に応じてパラメータを設定して実行
 
+<details>
+<summary>📋 ワークフロー一覧 (データ収集 / 開発・CI/CD) (クリックして展開)</summary>
+
 ### ワークフロー一覧
 
 #### データ収集ワークフロー
@@ -542,6 +555,8 @@ flowchart TD
 | **🧪 テストスイート実行**    | `test.yml`               | 自動テスト実行         | プッシュ または PR または 手動実行 |
 | **🔍 Claude コードレビュー** | `claude-code-review.yml` | AIによるコードレビュー | PR作成・更新時                     |
 | **🤖 Claude Code 統合**      | `claude.yml`             | Claude AIとの統合      | Issue/PRコメント                   |
+
+</details>
 
 ## ⚙️ 必要な設定
 
@@ -633,7 +648,10 @@ uv run pytest tests/test_enhanced_fetcher.py
 
 ### 🛠️ 設定ファイル
 
-`config/config.yml` で以下の詳細設定が可能です:
+`config/config.yml` で詳細設定が可能です。
+
+<details>
+<summary>⚙️ 設定項目の詳細 (収集 / ストレージ / 品質管理 / 通知 / Pull Request) (クリックして展開)</summary>
 
 #### 収集設定
 
@@ -684,6 +702,8 @@ PR_LABELS:
 ```
 
 カスタマイズが必要な場合は、`.github/workflows/fetch-data.yml` の該当箇所を直接編集してください。
+
+</details>
 
 ## 📝 ライセンスおよび利用規約
 


### PR DESCRIPTION
## Summary

「2回目以降は読まなくていい」リファレンス情報を `<details>` で折りたたみ、READMEのデフォルト表示を **738行→約347行 (47%)** に圧縮。
ユーザー指摘の「フロー図 (Mermaid) が大きすぎる」も折りたたみ対象に含む。

## 折りたたんだセクション (4箇所)

| セクション | 概要 |
|---|---|
| 📁 ディレクトリ構造 / 命名規則 / メタデータスキーマ v1.3.0 | データ仕様リファレンス |
| 🔄 処理フロー図 (Mermaid 28行) / ステップ詳細 / 注意事項 | 内部実装の説明 |
| 📋 ワークフロー一覧 (データ収集 + 開発・CI/CD) | YMLファイル対応表 |
| ⚙️ 設定ファイル詳細 (収集 / ストレージ / 品質管理 / 通知 / PR) | config.yml 各項目 |

## 常時展開維持 (Front Door として必要)

- タイトル / バッジ
- 📊 データ収集状況 (最新データ・統計・データ種別内訳・品質チェック概要)
- 📊 感染動向の可視化 (チャート + 直近追加の「読み方」)
- 📋 主な機能
- 📊 データ構造 — 「収集データタイプ9種類」テーブル (概観のみ)
- 🔄 GitHub Actions ワークフロー (自動実行説明・手動実行手順)
- ⚙️ GitHub Actions権限設定 (必須設定)
- 🚀 開発クイックスタート (uv インストール・データ取得・dev コマンド)
- 📝 ライセンス

## ベストプラクティス根拠

- Tilburg Science Hub / SciLifeLab guideline: READMEは「front door」、詳細はリンク先または折りたたみ
- GitHub-flavored Markdown `<details>` は visual clutter を減らしつつ全情報を保持

## Out of scope (今回見送り)

- Mermaid 図のノード簡略化 / コンパクト化 (今回は折りたたみのみ)
- README全体の docs/ 分離
- 英語Abstract追加
- CLAUDE.md / docs/data_structure_design.md 更新

## Test plan

- [x] `<details>` タグ数balanced (6開/6閉)
- [x] `uv run pre-commit run --files README.md` 全Pass
- [x] 折りたたみ境界に orphan text なし
- [x] 既存折りたたみ (品質警告2か所) は維持
- [x] 既存挙動への影響なし (README記載のみの変更)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **ドキュメント**
  * READMEの複雑な情報を折りたたみ表示（詳細展開可能）に変更し、ドキュメントをより読みやすく整理しました。データ構造、ワークフロー、設定詳細などが必要に応じて確認できるようになります。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kambarakun/fetch-tokyo-idsc-github-actions/pull/464?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->