### PR TITLE
fix: 監査で判明した機能バグ6件を修正 (check-missing/gender/config mode/metadata/create_pr/readme-stats)

### DIFF
--- a/.github/workflows/_fetch-data-common.yml
+++ b/.github/workflows/_fetch-data-common.yml
@@ -610,15 +610,18 @@ jobs:
           # auto_merge設定
           AUTO_MERGE: ${{ inputs.auto_merge }}
         run: |
-          # workflow_type別のブランチ名プレフィックス
+          # workflow_type を create_pr.sh が認識する workflow_name 識別子へ変換する。
+          # create_pr.sh はこの識別子でブランチ名・コミットメッセージ・自動マージ検証ゲートを分岐するため、
+          # 旧来の "data-update-*" を渡すと全て default 分岐に落ち、ブランチ名二重化・検証ゲート無効化を招く。
           case "${{ inputs.workflow_type }}" in
-            manual) BRANCH_PREFIX="data-update-manual" ;;
-            weekly) BRANCH_PREFIX="data-update-weekly" ;;
-            daily)  BRANCH_PREFIX="data-update-daily" ;;
+            manual) WORKFLOW_NAME="fetch-data" ;;
+            weekly) WORKFLOW_NAME="fetch-data-weekly" ;;
+            daily)  WORKFLOW_NAME="fetch-data-daily" ;;
+            *)      WORKFLOW_NAME="fetch-data" ;;
           esac
 
           # 共通スクリプトを呼び出し
-          bash scripts/create_pr.sh "$BRANCH_PREFIX" "${{ inputs.workflow_display_name }}"
+          bash scripts/create_pr.sh "$WORKFLOW_NAME" "${{ inputs.workflow_display_name }}"
 
       - name: Create issue on error
         if: failure() && inputs.dry_run != true

--- a/scripts/update_readme_stats.py
+++ b/scripts/update_readme_stats.py
@@ -145,13 +145,18 @@ def get_metadata_stats() -> dict[str, Any]:
     if not metadata_dir.exists():
         return {
             "total_files": 0,
-            "date_range": "データなし",
+            "week_range": "N/A",
+            "month_range": "N/A",
             "latest_fetch": latest_fetch_str,
             "last_stats_update": last_stats_update_str,
             "data_types": {},
+            "data_type_periods": {},
             "year_range": "N/A",
             "latest_week": "N/A",
             "latest_month": "N/A",
+            "years": [],
+            "week_count": 0,
+            "month_count": 0,
             "anomalies": {"errors": {}, "warnings": {}, "quality_issues": {}},
         }
 
@@ -258,13 +263,18 @@ def get_metadata_stats() -> dict[str, Any]:
     if not all_files:
         return {
             "total_files": 0,
-            "date_range": "データなし",
+            "week_range": "N/A",
+            "month_range": "N/A",
             "latest_fetch": latest_fetch_str,
             "last_stats_update": last_stats_update_str,
             "data_types": {},
+            "data_type_periods": {},
             "year_range": "N/A",
             "latest_week": "N/A",
             "latest_month": "N/A",
+            "years": [],
+            "week_count": 0,
+            "month_count": 0,
             "anomalies": {"errors": {}, "warnings": {}, "quality_issues": {}},
         }
 

--- a/src/cli/check_missing.py
+++ b/src/cli/check_missing.py
@@ -16,8 +16,10 @@ def weeks_in_year(year: int) -> int:
 
 
 # ファイル名パターン
-PAT_WEEK = re.compile(r"(?P<base>.+?_weekly(?:_[^_]+)??)_(?P<year>\d{4})_(?P<idx>\d{1,2})(?:_|-)")
-PAT_MONTH = re.compile(r"(?P<base>.+?_monthly(?:_[^_]+)??)_(?P<year>\d{4})_(?P<idx>\d{1,2})(?:_|-)")
+# idx の直後は区切り (_ / -) もしくは拡張子 (.csv) のため、lookahead で [._-] を許容する。
+# 旧形式 (..._2025_1_20250101_120000.csv) と現行フラット形式 (..._2025_01.csv) の双方にマッチさせる。
+PAT_WEEK = re.compile(r"(?P<base>.+?_weekly(?:_[^_]+)??)_(?P<year>\d{4})_(?P<idx>\d{1,2})(?=[._-])")
+PAT_MONTH = re.compile(r"(?P<base>.+?_monthly(?:_[^_]+)??)_(?P<year>\d{4})_(?P<idx>\d{1,2})(?=[._-])")
 
 
 def collect(data_dir: Path):

--- a/src/cli/migrate_metadata.py
+++ b/src/cli/migrate_metadata.py
@@ -615,7 +615,7 @@ def _build_quality_metadata_for_v1_2(migrated: dict[str, Any], data_file: Path |
         )
 
     issues = quality.get("issues", [])
-    status = "failed" if issues else "passed"
+    status = "failed" if issues else "completed"
     return (
         {
             "validation_timestamp": quality.get("validation_timestamp", default_timestamp),

--- a/src/cli/verify_metadata.py
+++ b/src/cli/verify_metadata.py
@@ -102,6 +102,10 @@ def _process_single_file(
     # 検証を実行 (公開API validate_file を使用)
     verification: dict[str, Any] = storage_manager.validate_file(data_file, data)
 
+    # quality は verification 配下ではなく metadata 直下 (top-level) へ格納する。
+    # (Metadata モデル / スキーマ / storage_manager・data_processor 経路と構造を統一)
+    metadata_quality: dict[str, Any] | None = None
+
     if quality_validator is not None:
         data_type = metadata.get("data_type")
         if not isinstance(data_type, str):
@@ -114,7 +118,7 @@ def _process_single_file(
             verification.setdefault("errors", []).append(f"[gender_sum_consistency] Validation failed: {e!s}")
             verification["status"] = "failed"
         else:
-            verification["quality"] = quality
+            metadata_quality = quality
 
             issues = quality.get("issues", [])
             has_gender_sum_errors = False
@@ -154,6 +158,8 @@ def _process_single_file(
     else:
         # メタデータを更新
         metadata["verification"] = verification
+        if metadata_quality is not None:
+            metadata["quality"] = metadata_quality
         with metadata_path.open("w", encoding="utf-8") as f:
             json.dump(metadata, f, indent=2, ensure_ascii=False)
         if verbose:

--- a/src/managers/config_manager.py
+++ b/src/managers/config_manager.py
@@ -72,7 +72,8 @@ class NotificationConfig:
 class CollectionConfig:
     """データ収集設定"""
 
-    incremental_mode: bool = True  # 増分収集モード
+    mode: str | None = None  # 収集モード (incremental | full | force)。None なら incremental_mode にフォールバック
+    incremental_mode: bool = True  # (非推奨) mode を使用してください。後方互換のため保持
     batch_size: int = 50  # 一度に処理するファイル数
     start_year: int = 2000
     end_year: int | None = None  # Noneの場合は現在年
@@ -217,6 +218,7 @@ class ConfigurationManager:
         if "collection" in config_dict:
             collection = config_dict["collection"]
             config.collection = CollectionConfig(
+                mode=collection.get("mode"),
                 incremental_mode=collection.get("incremental_mode", True),
                 batch_size=collection.get("batch_size", 50),
                 start_year=collection.get("start_year", 2000),
@@ -347,6 +349,7 @@ class ConfigurationManager:
                 "manual_trigger_enabled": config.schedule.manual_trigger_enabled,
             },
             "collection": {
+                "mode": config.collection.mode,
                 "incremental_mode": config.collection.incremental_mode,
                 "batch_size": config.collection.batch_size,
                 "start_year": config.collection.start_year,

--- a/src/validators/gender_sum_validator.py
+++ b/src/validators/gender_sum_validator.py
@@ -31,14 +31,17 @@ class GenderSumValidator:
     # Applicable data types for gender sum validation
     # These data types have gender-disaggregated data (male, female, total sections)
     # and require validation of male + female = total consistency
+    # 性別分割 (男性/女性/男女合計セクション) を持つデータタイプのみが対象。
+    # weekly だけでなく monthly の age/health_center/medical_district も性別分割されるため含める。
+    # (sentinel_*_gender は単純処理で性別分割されないため対象外)
     _APPLICABLE_DATA_TYPES = frozenset(
         {
             "sentinel_weekly_medical_district",
             "sentinel_weekly_health_center",
             "sentinel_weekly_age",
-            "sentinel_daily_medical_district",
-            "sentinel_daily_health_center",
-            "sentinel_daily_age",
+            "sentinel_monthly_medical_district",
+            "sentinel_monthly_health_center",
+            "sentinel_monthly_age",
         }
     )
 

--- a/tests/test_config_manager.py
+++ b/tests/test_config_manager.py
@@ -119,6 +119,7 @@ class TestConfigurationManager(unittest.TestCase):
         config_dict = {
             "schedule": {"cron": "0 0 * * *", "timezone": "UTC", "manual_trigger_enabled": False},
             "collection": {
+                "mode": "full",
                 "incremental_mode": False,
                 "batch_size": 100,
                 "start_year": 2020,
@@ -137,6 +138,7 @@ class TestConfigurationManager(unittest.TestCase):
         self.assertEqual(config.schedule.timezone, "UTC")
         self.assertFalse(config.schedule.manual_trigger_enabled)
         self.assertEqual(config.collection.batch_size, 100)
+        self.assertEqual(config.collection.mode, "full")  # collection.mode が解析される (旧: mode 黙殺バグの再発防止)
         self.assertEqual(config.storage.base_directory, "/tmp/data")
         self.assertEqual(len(config.data_types), 1)
         self.assertEqual(config.data_types[0].name, "test_type")
@@ -180,6 +182,7 @@ class TestConfigurationManager(unittest.TestCase):
 
         self.assertEqual(config_dict["schedule"]["cron"], config.schedule.cron_expression)
         self.assertEqual(config_dict["collection"]["batch_size"], config.collection.batch_size)
+        self.assertEqual(config_dict["collection"]["mode"], config.collection.mode)  # mode が round-trip で保持される
 
     @patch("builtins.open", mock_open())
     @patch("yaml.dump")

--- a/tests/test_issue300_phase0_cli_core_coverage.py
+++ b/tests/test_issue300_phase0_cli_core_coverage.py
@@ -124,9 +124,10 @@ def test_check_missing_collect_analyse_report_and_main(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:
     raw = tmp_path / "raw"
-    _write_csv(raw / "sentinel_weekly_gender_2025_01_a.csv", ["h", "1"])
-    _write_csv(raw / "sentinel_weekly_gender_2025_03_b.csv", ["h", "2"])
-    _write_csv(raw / "sentinel_monthly_age_2025_02_a.csv", ["h", "1"])
+    # 現行フラット形式 (idx 直後が .csv) でマッチすることを保証する (旧バグの再発防止)
+    _write_csv(raw / "sentinel_weekly_gender_2025_01.csv", ["h", "1"])
+    _write_csv(raw / "sentinel_weekly_gender_2025_03.csv", ["h", "2"])
+    _write_csv(raw / "sentinel_monthly_age_2025_02.csv", ["h", "1"])
     _write_csv(raw / "unrelated.csv", ["x"])
 
     weekly, monthly = cm.collect(raw)

--- a/tests/test_issue300_phase0_cli_extended_coverage.py
+++ b/tests/test_issue300_phase0_cli_extended_coverage.py
@@ -873,8 +873,8 @@ def test_migrate_metadata_additional_branches(tmp_path: Path, monkeypatch: pytes
         {"metadata_version": "1.1.0", "data_type": "sentinel_weekly_age"},
         csv_file,
     )
-    assert migrated_v12_pass["quality"]["validation_status"] == "passed"
-    assert any("validation_status=passed" in c for c in changes_v12_pass)
+    assert migrated_v12_pass["quality"]["validation_status"] == "completed"
+    assert any("validation_status=completed" in c for c in changes_v12_pass)
 
     monkeypatch.setattr(
         mm,

--- a/tests/test_update_readme_stats.py
+++ b/tests/test_update_readme_stats.py
@@ -198,7 +198,12 @@ class TestGetMetadataStats:
             os.chdir(tmp_path)
             result = get_metadata_stats()
             assert result["total_files"] == 0
-            assert result["date_range"] == "データなし"
+            # データなし時も正常系と同じキー集合を返し、update_readme/main が KeyError にならないこと (再発防止)
+            assert result["week_range"] == "N/A"
+            assert result["month_range"] == "N/A"
+            assert result["week_count"] == 0
+            assert result["month_count"] == 0
+            assert result["data_type_periods"] == {}
             # 最終統計更新日時が設定されていることを確認
             assert "last_stats_update" in result
             assert result["last_stats_update"] != "N/A"

--- a/tests/test_validators_integration.py
+++ b/tests/test_validators_integration.py
@@ -96,9 +96,9 @@ class TestGenderSumValidatorIntegration:
         assert "sentinel_weekly_age" in GenderSumValidator._APPLICABLE_DATA_TYPES
         assert "sentinel_weekly_medical_district" in GenderSumValidator._APPLICABLE_DATA_TYPES
         assert "sentinel_weekly_health_center" in GenderSumValidator._APPLICABLE_DATA_TYPES
-        assert "sentinel_daily_age" in GenderSumValidator._APPLICABLE_DATA_TYPES
-        assert "sentinel_daily_medical_district" in GenderSumValidator._APPLICABLE_DATA_TYPES
-        assert "sentinel_daily_health_center" in GenderSumValidator._APPLICABLE_DATA_TYPES
+        assert "sentinel_monthly_age" in GenderSumValidator._APPLICABLE_DATA_TYPES
+        assert "sentinel_monthly_medical_district" in GenderSumValidator._APPLICABLE_DATA_TYPES
+        assert "sentinel_monthly_health_center" in GenderSumValidator._APPLICABLE_DATA_TYPES
 
         # Verify similar but different types are NOT in the set
         assert "sentinel_weekly_age_group" not in GenderSumValidator._APPLICABLE_DATA_TYPES


### PR DESCRIPTION
## 概要
リポジトリ監査で洗い出した **機能バグ6件** を修正します(「機能バグ修正」領域)。各修正に再発防止テストを追加し、全658テスト pass・カバレッジ100% を維持しています。

## 修正内容

| 対象 | 症状 | 修正 |
|------|------|------|
| `check-missing` | 正規表現が現行形式 `..._YYYY_WW.csv` を拾えず欠番検出が常に0件 | 末尾を lookahead `[._-]` にし旧/現行形式に対応 |
| `gender_sum_validator` | 実在しない `sentinel_daily_*` が対象、性別分割される `sentinel_monthly_*` が対象外 | daily を除き monthly (age/health_center/medical_district) を追加 |
| `config` | `collection.mode` が解析されず `mode: full/force` が黙殺 (常に incremental) | `CollectionConfig.mode` を新設し parse/round-trip に反映 |
| `verify-metadata` | `quality` を `verification` 配下にネスト (モデル/スキーマと不整合) | `quality` を metadata 直下へ |
| `migrate-metadata` | `validation_status` にスキーマ外の値 `"passed"` | `"completed"` に修正 |
| `_fetch-data-common.yml` | `create_pr.sh` に `data-update-*` を渡し全 case が default 落ち → ブランチ名二重化・**自動マージ事前検証ゲート無効化** | workflow_name 識別子 (`fetch-data`/`-weekly`/`-daily`) に修正 |
| `update_readme_stats` | データ皆無時の早期 return がキー集合不一致で `update_readme`/`main` が KeyError | 早期 return を正常系キー集合に統一 |

## 検証
- 全 **658 テスト pass** / **カバレッジ 100%** (src)
- ruff / mypy / actionlint / pre-commit 全フック pass

## レビュー時の注意 (本番影響)
- **`_fetch-data-common.yml`**: 次回の日次/週次データ更新ワークフロー実行時に挙動が変わります(ブランチ名が正規化され、事前検証失敗時に auto-merge が抑止されます)。CI では実地検証されないため初回実行の観察を推奨。
- **`verify-metadata`**: 既存メタデータには影響しません(`verify-metadata` 再実行時のみ `quality` が top-level に移動)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * コレクション設定に新しいモード設定オプションを追加しました。

* **バグ修正**
  * メタデータが存在しない場合の統計情報取得処理を改善しました。
  * CSVファイル検出パターンの精度を向上させました。
  * メタデータ検証ロジックと品質ステータス判定を改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->