### PR TITLE
chore(pre-commit): フックを CI/lock と同期し再現性を確保 (ruff 0.6→0.15.15, ruff-format削除等)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@
 repos:
   # 基本的なファイルチェック
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
+    rev: v5.0.0
     hooks:
       - id: trailing-whitespace
         name: 末尾の空白を削除
@@ -38,7 +38,7 @@ repos:
 
   # Pythonコードフォーマット (isort)
   - repo: https://github.com/PyCQA/isort
-    rev: 5.13.2
+    rev: 7.0.0
     hooks:
       - id: isort
         name: import文の整理
@@ -46,26 +46,27 @@ repos:
 
   # Pythonコードフォーマット (black)
   - repo: https://github.com/psf/black
-    rev: 24.3.0
+    rev: 25.12.0
     hooks:
       - id: black
         name: Pythonコードのフォーマット
         language_version: python3.11
         args: ["--line-length", "120"]
 
-  # Pythonコード品質チェック (Ruff - 高速な統合リンター)
+  # Pythonコード品質チェック (Ruff リンター)
+  # 注: コードフォーマットは black に一任する。ruff-format と black を二重適用すると
+  # 両者が互いに異なる整形を要求し競合する (バージョン更新時に顕在化) ため ruff-format は使わない。
+  # CI (test.yml) も black --check を採用しており black 一本化が整合的。
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.6.0
+    rev: v0.15.15
     hooks:
       - id: ruff
         name: Ruff リンター
         args: ["--fix", "--exit-non-zero-on-fix"]
-      - id: ruff-format
-        name: Ruff フォーマッター
 
   # 型チェック (mypy)
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.8.0
+    rev: v1.20.2
     hooks:
       - id: mypy
         name: Python型チェック
@@ -73,8 +74,9 @@ repos:
         additional_dependencies: [types-requests, types-PyYAML]
 
   # Markdownファイルのフォーマット
-  - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v3.1.0
+  # mirrors-prettier (pre-commit 公式) は 2024 年にアーカイブされたため後継の rbubley/mirrors-prettier を使用
+  - repo: https://github.com/rbubley/mirrors-prettier
+    rev: v3.8.3
     hooks:
       - id: prettier
         name: Markdown/YAML/JSONのフォーマット


### PR DESCRIPTION
## 概要
ローカル pre-commit と CI (uv) で **別バージョンの lint/format ツールが走る再現性問題** を解消します(「pre-commit/CI再現性」領域)。

## 背景
- CI の lint (test.yml) は `uv run` (lock のバージョン) で実行: ruff **0.15.15** / black 25.12.0 / isort 7.0.0 / mypy 1.20.2
- 一方 pre-commit は ruff **0.6.0** / black 24.3.0 / isort 5.13.2 / mypy 1.8.0 と大きく乖離
- → 開発者がローカルで pre-commit を通してコミットしても、CI で別バージョンが走り結果が食い違う

## 変更
- `ruff-pre-commit` v0.6.0 → **v0.15.15** (CI/lock と一致)
- `black` 24.3.0 → 25.12.0 / `isort` 5.13.2 → 7.0.0 / `mirrors-mypy` v1.8.0 → v1.20.2
- `pre-commit-hooks` v4.5.0 → v5.0.0
- `mirrors-prettier` (2024年アーカイブ済) → 後継 `rbubley/mirrors-prettier` v3.8.3
- **`ruff-format` フックを削除**: black と二重適用すると互いに異なる整形を要求し競合(バージョン更新時に5ファイルで顕在化)。CI も black を採用しているため black に一本化

## 補足 (フォローアップ候補)
- 本リポジトリは Dependabot が `github-actions`/`uv` のみ対象で **pre-commit ecosystem 未設定** のため、今後も手動更新が必要です。`.github/dependabot.yml` に `package-ecosystem: "pre-commit"` を追加すると自動追従できます(別PR候補)。
- prettier 3.8.3 では既存 markdown が再整形対象になります(本PRには含めず、ドキュメント整合性の修正とまとめて適用予定)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 開発環境のコード品質チェックツールを更新しました。
  * Pre-commitフックのバージョンを更新し、Python・Markdown関連のリント・フォーマットツール設定を最適化。フォーマッタの統一化により開発効率を向上させました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->