### PR TITLE
chore(dependabot): pre-commit フックの自動更新を有効化

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -71,3 +71,24 @@ updates:
       type-stubs:
         patterns:
           - "types-*"
+
+  # 🪝 pre-commit フックを更新 (2026-03-10 から Dependabot ネイティブサポート)
+  - package-ecosystem: "pre-commit"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Asia/Tokyo"
+    labels:
+      - "dependencies"
+      - "pre-commit"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    open-pull-requests-limit: 5
+    # メジャーバージョンアップは無視 (破壊的変更を手動でレビュー)
+    # actionlint は SHA pin 運用のため Dependabot も SHA を更新する。github-actions 同様レビュー必須。
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]


### PR DESCRIPTION
## 概要
監査フォローアップ。**Dependabot に pre-commit ecosystem を追加** し、`.pre-commit-config.yaml` のフック rev を自動更新できるようにします。

## 背景
- これまで Dependabot は `github-actions` / `uv` のみ対象で、**pre-commit フックは自動更新されず** 手動管理だった
- 実際に ruff が 0.6.0 のまま長期放置され、#487 で手動同期する必要があった
- **Dependabot は 2026-03-10 から pre-commit hooks をネイティブサポート** (rev を解析し新タグ/SHA への更新PRを作成。SHA pin・グループ化・YAML整形保持に対応)

## 変更
- `.github/dependabot.yml` に `package-ecosystem: "pre-commit"` を追加
- weekly (月曜 09:00 JST)、メジャーバージョンは無視、`chore` プレフィックス (他 ecosystem と統一)
- actionlint は SHA pin 運用のため、Dependabot PR も SHA を更新する点に注意 (github-actions 同様レビュー必須)

Source: [Dependabot now supports pre-commit hooks - GitHub Changelog](https://github.blog/changelog/2026-03-10-dependabot-now-supports-pre-commit-hooks/)

🤖 Generated with [Claude Code](https://claude.com/claude-code)