### PR TITLE
feat(validation): メタデータの JSON Schema 検証を CI に追加 (drift 検出)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -93,6 +93,10 @@ jobs:
           uv run python -m py_compile src/managers/config_manager.py
           uv run python -m py_compile src/managers/storage_manager.py
 
+      - name: Validate metadata against JSON Schema (v1.3.0)
+        run: |
+          uv run python scripts/validate_metadata_schema.py
+
       - name: Summary
         if: always()
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dev = [
     "types-requests>=2.33.0.20260518",
     "types-PyYAML>=6.0.1",
     "pre-commit>=4.6.0",
+    "jsonschema>=4.18.0",
 ]
 
 [project.scripts]

--- a/schemas/metadata-v1.3.schema.json
+++ b/schemas/metadata-v1.3.schema.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://github.com/kambarakun/fetch-tokyo-idsc-github-actions/schemas/metadata-v1.3.schema.json",
   "title": "Tokyo IDSC Metadata Schema (v1.3.0)",
-  "description": "Common metadata schema (v1.3.0) for Tokyo Infectious Disease Surveillance Center data files. NOTE: the filename is historically metadata-v1.1.schema.json; the authoritative schema version is 1.3.0 (see src/models/metadata.py::METADATA_VERSION). The file should be renamed to metadata-v1.3.schema.json in a follow-up.",
+  "description": "Common metadata schema (v1.3.0) for Tokyo Infectious Disease Surveillance Center data files. The authoritative schema version is 1.3.0 (see src/models/metadata.py::METADATA_VERSION). Validated against real metadata in CI via scripts/validate_metadata_schema.py.",
   "type": "object",
   "required": [
     "metadata_version",

--- a/scripts/validate_metadata_schema.py
+++ b/scripts/validate_metadata_schema.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""メタデータ JSON を JSON Schema (v1.3.0) で検証する.
+
+型定義 (src/models/metadata.py) とは独立した第2の検証層として、生成済みの
+全メタデータが schemas/metadata-v1.3.schema.json に適合するかを検証する。
+CI で実行し、schema と実データの drift / 構造崩れ (例: quality の格納位置ずれ) を
+早期検出することを目的とする。
+
+実行例:
+    uv run python scripts/validate_metadata_schema.py
+    uv run python scripts/validate_metadata_schema.py --schema schemas/metadata-v1.3.schema.json data/raw/.metadata
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections.abc import Iterable, Iterator
+from pathlib import Path
+
+from jsonschema import Draft202012Validator
+from jsonschema.exceptions import SchemaError
+
+# 個別メタデータではない (= schema 検証の対象外) 集約/インデックスファイル
+NON_METADATA_FILES = frozenset({"hash_index.json", "processing_log.json"})
+
+DEFAULT_SCHEMA = Path("schemas/metadata-v1.3.schema.json")
+DEFAULT_METADATA_DIRS = (Path("data/raw/.metadata"), Path("data/processed/.metadata"))
+
+# 不適合が大量に出た場合に表示を打ち切る上限
+_MAX_REPORTED = 50
+
+
+def iter_metadata_files(dirs: Iterable[Path]) -> Iterator[Path]:
+    """検証対象の個別メタデータ JSON を列挙する (非メタデータファイルは除外)."""
+    for directory in dirs:
+        if not directory.is_dir():
+            continue
+        for json_file in sorted(directory.glob("*.json")):
+            if json_file.name in NON_METADATA_FILES:
+                continue
+            yield json_file
+
+
+def validate(schema_path: Path, dirs: Iterable[Path]) -> tuple[int, list[tuple[Path, str]]]:
+    """全メタデータを検証し (検証件数, 違反リスト) を返す.
+
+    違反リストの各要素は (ファイルパス, 最初のエラーの要約) のタプル。
+    Validator はループ前に一度だけ生成し、再コンパイルによる性能劣化を避ける。
+    """
+    schema = json.loads(schema_path.read_text(encoding="utf-8"))
+    # schema 自体が有効な JSON Schema (Draft 2020-12) かを先に検証する (メタスキーマ検証)
+    Draft202012Validator.check_schema(schema)
+    validator = Draft202012Validator(schema)
+
+    total = 0
+    violations: list[tuple[Path, str]] = []
+    for json_file in iter_metadata_files(dirs):
+        total += 1
+        try:
+            data = json.loads(json_file.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            violations.append((json_file, f"JSON 読み込み失敗: {exc}"))
+            continue
+
+        errors = sorted(validator.iter_errors(data), key=lambda e: list(e.path))
+        if errors:
+            first = errors[0]
+            location = "/".join(str(p) for p in first.path) or "(root)"
+            violations.append((json_file, f"{location}: {first.message}"))
+
+    return total, violations
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI エントリポイント. 不適合があれば 1、スキーマ未検出は 2、成功は 0 を返す."""
+    parser = argparse.ArgumentParser(description="メタデータ JSON を JSON Schema (v1.3.0) で検証")
+    parser.add_argument("--schema", type=Path, default=DEFAULT_SCHEMA, help="スキーマファイルのパス")
+    parser.add_argument(
+        "metadata_dirs",
+        nargs="*",
+        type=Path,
+        help="検証対象の .metadata ディレクトリ (省略時は data/raw/.metadata と data/processed/.metadata)",
+    )
+    args = parser.parse_args(argv)
+
+    dirs = args.metadata_dirs or list(DEFAULT_METADATA_DIRS)
+
+    if not args.schema.is_file():
+        print(f"エラー: スキーマが見つかりません: {args.schema}", file=sys.stderr)
+        return 2
+
+    try:
+        total, violations = validate(args.schema, dirs)
+    except (SchemaError, json.JSONDecodeError, OSError) as exc:
+        print(f"エラー: スキーマの読み込み/検証に失敗しました: {exc}", file=sys.stderr)
+        return 2
+
+    if violations:
+        print(f"メタデータ schema 検証: {total}件中 {len(violations)}件が不適合 (schema: {args.schema.name})")
+        for path, message in violations[:_MAX_REPORTED]:
+            print(f"  {path}: {message}")
+        if len(violations) > _MAX_REPORTED:
+            print(f"  ... 他 {len(violations) - _MAX_REPORTED}件")
+        return 1
+
+    print(f"メタデータ schema 検証: {total}件すべて適合 (schema: {args.schema.name})")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_validate_metadata_schema.py
+++ b/tests/test_validate_metadata_schema.py
@@ -1,0 +1,165 @@
+"""scripts/validate_metadata_schema.py のテスト.
+
+実データに依存せず tmp_path 上の最小スキーマ + メタデータでロジックを検証する。
+実 schema vs 実データの整合は CI の独立ステップ (uv run python scripts/validate_metadata_schema.py) が担う。
+"""
+
+import json
+from pathlib import Path
+
+from scripts.validate_metadata_schema import (
+    NON_METADATA_FILES,
+    iter_metadata_files,
+    main,
+    validate,
+)
+
+# 最小スキーマ: metadata_version (string) を必須とするだけ
+SIMPLE_SCHEMA = {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "required": ["metadata_version"],
+    "properties": {"metadata_version": {"type": "string"}},
+    "additionalProperties": True,
+}
+
+
+def _write_json(path: Path, obj: object) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(obj), encoding="utf-8")
+
+
+def _make_schema(tmp_path: Path) -> Path:
+    schema = tmp_path / "schema.json"
+    _write_json(schema, SIMPLE_SCHEMA)
+    return schema
+
+
+def test_iter_metadata_files_excludes_non_metadata(tmp_path):
+    """hash_index.json / processing_log.json は列挙対象から除外される."""
+    md = tmp_path / ".metadata"
+    _write_json(md / "a.json", {"metadata_version": "1.3.0"})
+    _write_json(md / "hash_index.json", {})
+    _write_json(md / "processing_log.json", {"processing": []})
+
+    names = [f.name for f in iter_metadata_files([md])]
+
+    assert names == ["a.json"]
+    assert {"hash_index.json", "processing_log.json"} == NON_METADATA_FILES
+
+
+def test_iter_metadata_files_skips_missing_dir(tmp_path):
+    """存在しないディレクトリは黙ってスキップする."""
+    assert list(iter_metadata_files([tmp_path / "does-not-exist"])) == []
+
+
+def test_validate_all_conforming(tmp_path):
+    """全件適合の場合は違反ゼロ."""
+    schema = _make_schema(tmp_path)
+    md = tmp_path / ".metadata"
+    _write_json(md / "a.json", {"metadata_version": "1.3.0"})
+    _write_json(md / "b.json", {"metadata_version": "1.2.0", "extra": 1})
+
+    total, violations = validate(schema, [md])
+
+    assert total == 2
+    assert violations == []
+
+
+def test_validate_detects_missing_required_field(tmp_path):
+    """必須フィールド欠落を検出する (processing_log で実際に起きた不整合の縮図)."""
+    schema = _make_schema(tmp_path)
+    md = tmp_path / ".metadata"
+    _write_json(md / "good.json", {"metadata_version": "1.3.0"})
+    _write_json(md / "bad.json", {"name": "x"})
+
+    total, violations = validate(schema, [md])
+
+    assert total == 2
+    assert len(violations) == 1
+    assert violations[0][0].name == "bad.json"
+    assert "metadata_version" in violations[0][1]
+
+
+def test_validate_handles_invalid_json(tmp_path):
+    """壊れた JSON は違反として報告し、処理を継続する."""
+    schema = _make_schema(tmp_path)
+    md = tmp_path / ".metadata"
+    md.mkdir()
+    (md / "broken.json").write_text("{ invalid json", encoding="utf-8")
+
+    total, violations = validate(schema, [md])
+
+    assert total == 1
+    assert len(violations) == 1
+    assert "JSON 読み込み失敗" in violations[0][1]
+
+
+def test_validate_reports_error_location(tmp_path):
+    """型エラーはフィールド位置付きで報告される."""
+    schema = _make_schema(tmp_path)
+    md = tmp_path / ".metadata"
+    _write_json(md / "wrong_type.json", {"metadata_version": 130})  # str でなく int
+
+    _, violations = validate(schema, [md])
+
+    assert len(violations) == 1
+    assert "metadata_version" in violations[0][1]
+
+
+def test_main_success(tmp_path, capsys):
+    """全適合時は終了コード0と適合メッセージ."""
+    schema = _make_schema(tmp_path)
+    md = tmp_path / ".metadata"
+    _write_json(md / "a.json", {"metadata_version": "1.3.0"})
+
+    rc = main(["--schema", str(schema), str(md)])
+
+    assert rc == 0
+    assert "すべて適合" in capsys.readouterr().out
+
+
+def test_main_violation(tmp_path, capsys):
+    """不適合時は終了コード1と不適合メッセージ."""
+    schema = _make_schema(tmp_path)
+    md = tmp_path / ".metadata"
+    _write_json(md / "bad.json", {})
+
+    rc = main(["--schema", str(schema), str(md)])
+
+    assert rc == 1
+    assert "不適合" in capsys.readouterr().out
+
+
+def test_main_schema_not_found(tmp_path, capsys):
+    """スキーマファイル不在時は終了コード2."""
+    rc = main(["--schema", str(tmp_path / "missing.json"), str(tmp_path)])
+
+    assert rc == 2
+    assert "見つかりません" in capsys.readouterr().err
+
+
+def test_main_truncates_many_violations(tmp_path, capsys):
+    """違反が表示上限 (50) を超えると残件数を表示する."""
+    schema = _make_schema(tmp_path)
+    md = tmp_path / ".metadata"
+    for i in range(55):
+        _write_json(md / f"bad{i:02d}.json", {})
+
+    rc = main(["--schema", str(schema), str(md)])
+
+    assert rc == 1
+    assert "他 5件" in capsys.readouterr().out
+
+
+def test_main_invalid_schema(tmp_path, capsys):
+    """スキーマ自体が無効な JSON Schema の場合は終了コード2 (メタスキーマ検証)."""
+    bad_schema = tmp_path / "bad_schema.json"
+    _write_json(bad_schema, {"type": "not-a-valid-type"})
+    md = tmp_path / ".metadata"
+    _write_json(md / "a.json", {"metadata_version": "1.3.0"})
+
+    rc = main(["--schema", str(bad_schema), str(md)])
+
+    assert rc == 2
+    assert "スキーマ" in capsys.readouterr().err

--- a/uv.lock
+++ b/uv.lock
@@ -3,6 +3,15 @@ revision = 3
 requires-python = "==3.11.*"
 
 [[package]]
+name = "attrs"
+version = "26.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9a/8e/82a0fe20a541c03148528be8cac2408564a6c9a0cc7e9171802bc1d26985/attrs-26.1.0.tar.gz", hash = "sha256:d03ceb89cb322a8fd706d4fb91940737b6642aa36998fe130a9bc96c985eff32", size = 952055, upload-time = "2026-03-19T14:22:25.026Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl", hash = "sha256:c647aa4a12dfbad9333ca4e71fe62ddc36f4e63b2d260a37a8b83d2f043ac309", size = 67548, upload-time = "2026-03-19T14:22:23.645Z" },
+]
+
+[[package]]
 name = "black"
 version = "25.12.0"
 source = { registry = "https://pypi.org/simple" }
@@ -220,6 +229,33 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/63/53/4f3c058e3bace40282876f9b553343376ee687f3c35a525dc79dbd450f88/isort-7.0.0.tar.gz", hash = "sha256:5513527951aadb3ac4292a41a16cbc50dd1642432f5e8c20057d414bdafb4187", size = 805049, upload-time = "2025-10-11T13:30:59.107Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7f/ed/e3705d6d02b4f7aea715a353c8ce193efd0b5db13e204df895d38734c244/isort-7.0.0-py3-none-any.whl", hash = "sha256:1bcabac8bc3c36c7fb7b98a76c8abb18e0f841a3ba81decac7691008592499c1", size = 94672, upload-time = "2025-10-11T13:30:57.665Z" },
+]
+
+[[package]]
+name = "jsonschema"
+version = "4.26.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "jsonschema-specifications" },
+    { name = "referencing" },
+    { name = "rpds-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b3/fc/e067678238fa451312d4c62bf6e6cf5ec56375422aee02f9cb5f909b3047/jsonschema-4.26.0.tar.gz", hash = "sha256:0c26707e2efad8aa1bfc5b7ce170f3fccc2e4918ff85989ba9ffa9facb2be326", size = 366583, upload-time = "2026-01-07T13:41:07.246Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/69/90/f63fb5873511e014207a475e2bb4e8b2e570d655b00ac19a9a0ca0a385ee/jsonschema-4.26.0-py3-none-any.whl", hash = "sha256:d489f15263b8d200f8387e64b4c3a75f06629559fb73deb8fdfb525f2dab50ce", size = 90630, upload-time = "2026-01-07T13:41:05.306Z" },
+]
+
+[[package]]
+name = "jsonschema-specifications"
+version = "2025.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "referencing" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/74/a633ee74eb36c44aa6d1095e7cc5569bebf04342ee146178e2d36600708b/jsonschema_specifications-2025.9.1.tar.gz", hash = "sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d", size = 32855, upload-time = "2025-09-08T01:34:59.186Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl", hash = "sha256:98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe", size = 18437, upload-time = "2025-09-08T01:34:57.871Z" },
 ]
 
 [[package]]
@@ -572,6 +608,20 @@ wheels = [
 ]
 
 [[package]]
+name = "referencing"
+version = "0.37.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "rpds-py" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/22/f5/df4e9027acead3ecc63e50fe1e36aca1523e1719559c499951bb4b53188f/referencing-0.37.0.tar.gz", hash = "sha256:44aefc3142c5b842538163acb373e24cce6632bd54bdb01b21ad5863489f50d8", size = 78036, upload-time = "2025-10-13T15:30:48.871Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/58/ca301544e1fa93ed4f80d724bf5b194f6e4b945841c5bfd555878eea9fcb/referencing-0.37.0-py3-none-any.whl", hash = "sha256:381329a9f99628c9069361716891d34ad94af76e461dcb0335825aecc7692231", size = 26766, upload-time = "2025-10-13T15:30:47.625Z" },
+]
+
+[[package]]
 name = "requests"
 version = "2.34.2"
 source = { registry = "https://pypi.org/simple" }
@@ -584,6 +634,41 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ac/c3/e2a2b89f2d3e2179abd6d00ebd70bff6273f37fb3e0cc209f48b39d00cbf/requests-2.34.2.tar.gz", hash = "sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed", size = 142856, upload-time = "2026-05-14T19:25:27.735Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl", hash = "sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0", size = 73075, upload-time = "2026-05-14T19:25:26.443Z" },
+]
+
+[[package]]
+name = "rpds-py"
+version = "2026.5.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2e/43/25a8dcd3feedd735039a8f0b5b7e3b118232b5eae288c4fd9ab200d41094/rpds_py-2026.5.1.tar.gz", hash = "sha256:07b24fea40541e28570e5b795a4a38fbdcd12550c06bd0748005ecc8116ca256", size = 64459, upload-time = "2026-05-28T12:02:13.232Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4f/a0/acf8b6fc20bfdcd3a45bd3f57680fb198e157b7e997b9123b10763798bd2/rpds_py-2026.5.1-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:3397a5ed7174dc2786bb214030232fc36fe8e5584fec43a9952cc542b1a12036", size = 355609, upload-time = "2026-05-28T11:58:50.78Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/95/f8203fd997484b1690a6869cd0e503b6c3c6be55b0ecc36d1a491fe742f0/rpds_py-2026.5.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:99ab6ba7bfa2cb0f96a04e3652355bf04e3f51aceb1e943b8541dab7ba4828cc", size = 348460, upload-time = "2026-05-28T11:58:52.374Z" },
+    { url = "https://files.pythonhosted.org/packages/33/8c/b47326ad2f0be545a5e5c1a55937a12afaea7d392ba2837bb9680f57e6c9/rpds_py-2026.5.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d0efbe45632665e53e3db8fe1e5692db58fc5cb9bab4459d570b83efefe11164", size = 381031, upload-time = "2026-05-28T11:58:53.775Z" },
+    { url = "https://files.pythonhosted.org/packages/22/0b/e83bbd97ffac6f6389b605cd4e1c8ac5761dc7e977769c9255d8c5adb7bd/rpds_py-2026.5.1-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:01d17b29c0c23d82b1f4751147ec49cf451f1fc2554eb9ef5f957e55d2656ead", size = 387121, upload-time = "2026-05-28T11:58:55.243Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/0e/d285d1bc8864245919c61e1ca82263e4a66d337759c3a4cef72766ff9afc/rpds_py-2026.5.1-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:7559f72b94ae52659086c595dfa017cde03155f7832071d30959049052cb3ece", size = 501026, upload-time = "2026-05-28T11:58:56.788Z" },
+    { url = "https://files.pythonhosted.org/packages/86/06/ccb2109a1e543437b5e43816f2b43b9554cc6783145528a4e3711e05c011/rpds_py-2026.5.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9e25b7088f9ccbfc0dfcaa52bf969300ca229e10ecf758974ebcbb080a4b37bb", size = 391865, upload-time = "2026-05-28T11:58:58.298Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/33/237173db1cfef10105b3839a24de00eb8d2a523711add4632447cdf0aedd/rpds_py-2026.5.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:613fc4ee9eaef26dc5840666214dd6fbcebcf32f46e76f4abc473059f4e13dda", size = 378012, upload-time = "2026-05-28T11:58:59.589Z" },
+    { url = "https://files.pythonhosted.org/packages/97/64/1eae54e34d5161f9969295e80bd6b62a55f2b6ac5f2a5b60d02c2140e758/rpds_py-2026.5.1-cp311-cp311-manylinux_2_31_riscv64.whl", hash = "sha256:85264a90ff4c05c1568dd65f5921c837614b67c60358fb4c17df3b7f2e90690a", size = 391111, upload-time = "2026-05-28T11:59:01.104Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/34/5bb334a5a0f65d77869217c4654f34c78a7d11b93938a3c076a2edeafc52/rpds_py-2026.5.1-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:fe71bca7d547acb17027c7fd1624ff8aae623499c498d3e7011182c4de5c25e0", size = 409225, upload-time = "2026-05-28T11:59:02.433Z" },
+    { url = "https://files.pythonhosted.org/packages/16/0f/007ec21283b5b040b4ec3bd95e0402591e22bfa7d5c93dfe01c465c2d2d7/rpds_py-2026.5.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:a05fa4f41f37ec97c9c260441a940450a192f78d774d2b097eee1379f1e1246a", size = 556487, upload-time = "2026-05-28T11:59:04.012Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/10/5437c94508169b6b22d8418fef7a66e9ffb5f3b9e9c94460f2eedafe06ff/rpds_py-2026.5.1-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:df1d2a1996755b24b9ecee92cb4d36c28f86f464a6a173349c26bab41e94b8c2", size = 620798, upload-time = "2026-05-28T11:59:05.485Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/d5/9937dce4d6bda74157b954e7d1460db05a22f5929dccfeeba1ed27a93df0/rpds_py-2026.5.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:8895840ac4809e5f60c88fd07617cd71326e73d6e5a8aa783c5c0f7c24985de2", size = 584053, upload-time = "2026-05-28T11:59:06.837Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/31/750617dd0ae1752471bf43f9e41d263398fae7cde7849d23b8574a70e617/rpds_py-2026.5.1-cp311-cp311-win32.whl", hash = "sha256:3684a59b158a7683aaeb8e25352e9a9dd2122cec78f2d8530266e4f91b4c7b3f", size = 214390, upload-time = "2026-05-28T11:59:08.402Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/bb/3dcab0e1d9516303f2eb672a5d6f62eca5a69e2886301e9c8c54b520c39b/rpds_py-2026.5.1-cp311-cp311-win_amd64.whl", hash = "sha256:7bd530e6a530bb3ea892f194fafa455f3516ac25ecf7143fd33c09be62b0470a", size = 231097, upload-time = "2026-05-28T11:59:09.786Z" },
+    { url = "https://files.pythonhosted.org/packages/49/d6/c6bbf5cb1cf12b9732df8074b57f6ef8341ba884c95d40632ae8bddb44e4/rpds_py-2026.5.1-cp311-cp311-win_arm64.whl", hash = "sha256:0a5ae4dbe43c1076983b72616496919872ae7bbe7a1e21cc48336bc3154d130b", size = 226361, upload-time = "2026-05-28T11:59:11.079Z" },
+    { url = "https://files.pythonhosted.org/packages/42/56/3fe0fb34820ff667be791b3a3c22b85e8bcba54e9c832f47438c191fa7be/rpds_py-2026.5.1-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:edf2765d84e42447f112ad877af8fe1db0089aaec5b28e88d6eab45e7fe99cea", size = 357151, upload-time = "2026-05-28T12:01:53.43Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/f2/3eb9ccdb9f143b8c9b003978898cb497f942a324c077401e6b8834238e63/rpds_py-2026.5.1-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:ad3773236e95f7f33991eb125224b7da66f206504d032a253a02da7e134519fb", size = 350195, upload-time = "2026-05-28T12:01:54.901Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/24/dbda232bc4f3ed732120692ab0d2c8402cb020516556d8bee622dcef2413/rpds_py-2026.5.1-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a04df86b3f0fade39ec8fd0e0aab089b1da9fbd2b48df778a57ef96f5e7d38df", size = 381850, upload-time = "2026-05-28T12:01:56.601Z" },
+    { url = "https://files.pythonhosted.org/packages/40/30/32e769839a358f78810c234f160f2cc21d1e4e47e1c0e0e0d535be5a0219/rpds_py-2026.5.1-pp311-pypy311_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:6142dbd80c4df62a5d899f0d616d417f84e0bc8d32526c8e5589019d75d028a7", size = 387899, upload-time = "2026-05-28T12:01:58.212Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/86/ec84d243aadb3b34b71dd26a010d0930b2d284ff5fc9a69fec53810ee6fd/rpds_py-2026.5.1-pp311-pypy311_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0b35217adefe87f2fe4db7e9766cabe84744bfe9616d9667be18988928c7f2dc", size = 501618, upload-time = "2026-05-28T12:01:59.888Z" },
+    { url = "https://files.pythonhosted.org/packages/74/25/b60e52686bbff777a64f9e4f4d3dd57980dc846913777177a2c92e4937aa/rpds_py-2026.5.1-pp311-pypy311_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b95d5e11fc712b752081183a55a244c03cd00570489edd7014d8899f8ceb8162", size = 394003, upload-time = "2026-05-28T12:02:01.482Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/c7/b3a6a588cc2219510ef3f42e207483a93950bedd1e3a0fd4015c95cff9e5/rpds_py-2026.5.1-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:141c9498daf2ace9eda35d2b0e376f9ea8b058d84f2aef4f96fccfd449a2f251", size = 379778, upload-time = "2026-05-28T12:02:03.197Z" },
+    { url = "https://files.pythonhosted.org/packages/31/00/c7dba3fc8a3da8cb3f6db1eb3386be4d79c2e97c6890d20eb9ac66ae8c43/rpds_py-2026.5.1-pp311-pypy311_pp73-manylinux_2_31_riscv64.whl", hash = "sha256:6f249f8b860a200ad35193af961183ebe9132710484e6f6ce0cf89fd83c63a9a", size = 392359, upload-time = "2026-05-28T12:02:04.817Z" },
+    { url = "https://files.pythonhosted.org/packages/93/dd/472ba494c70753f93745992c99855bee0636daf74e6984e5e003f150316f/rpds_py-2026.5.1-pp311-pypy311_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:e4abbf391a70be864920858bf360f4fb380577c9a0f732438a1996726e2c195b", size = 412820, upload-time = "2026-05-28T12:02:06.401Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/6f/93831a3bfe789542ed0c1d0d74b78b440f055d6dc3ea4640eba2d95e6e23/rpds_py-2026.5.1-pp311-pypy311_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:c74005a7bb87752acf351c93897ec63ad77a07a0da7ecad9c050e32e7286ba34", size = 557243, upload-time = "2026-05-28T12:02:08.013Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/ff/0b3d604614ffc77522c6b288fdbce68957eb583da1002aa65ba38ac0ee40/rpds_py-2026.5.1-pp311-pypy311_pp73-musllinux_1_2_i686.whl", hash = "sha256:8213afbe8a3a906fb9acb2014423fe3359ee783d0bf90995f70623a3217bfa6c", size = 623541, upload-time = "2026-05-28T12:02:09.661Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/ea/e7b0251441da9adfeaebcf29601d10f2a1455fcf0772fae9e7e19032bd96/rpds_py-2026.5.1-pp311-pypy311_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:8c43a8a973270fd173bf48cdf80bbe66312421cba68d40845034f174f2389049", size = 586326, upload-time = "2026-05-28T12:02:11.47Z" },
 ]
 
 [[package]]
@@ -649,6 +734,7 @@ dependencies = [
 dev = [
     { name = "black" },
     { name = "isort" },
+    { name = "jsonschema" },
     { name = "mypy" },
     { name = "pre-commit" },
     { name = "pytest" },
@@ -663,6 +749,7 @@ dev = [
 requires-dist = [
     { name = "black", marker = "extra == 'dev'", specifier = ">=23.0.0" },
     { name = "isort", marker = "extra == 'dev'", specifier = ">=5.12.0" },
+    { name = "jsonschema", marker = "extra == 'dev'", specifier = ">=4.18.0" },
     { name = "matplotlib", specifier = ">=3.10.9" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.20.2" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=4.6.0" },


### PR DESCRIPTION
## 概要
監査の最重要フォローアップ。**メタデータの JSON Schema 検証を CI に導入**します。「schema が参考用に置かれているだけで実行検証されず、v1.1 のまま陳腐化していた(誰も使わないので気づかれなかった)」という根本問題への恒久対策です。

## ベストプラクティス調査に基づく設計
- schema は SSOT (`schemas/`) で集中管理 ✅
- **CI で実プロダクションデータを検証し drift を早期 surface** (調査が推奨する核心) → 採用
- runtime/生成時検証は不採用 (型定義 TypedDict/dataclass で生成保証済み + 本番依存を増やさない)
- 大量ファイル (24,406件) + 除外2件のため、`check-jsonschema` の引数羅列より自前スクリプト (Validator を一度生成 = 再コンパイル回避) が適切

## 変更
- **`jsonschema` を dev 依存に追加** (本番 fetch-data は `uv sync` で dev 抜きのため非影響)
- **`scripts/validate_metadata_schema.py`**: 全 `.metadata` を Draft 2020-12 で検証。`hash_index.json`/`processing_log.json` (非メタデータ) を除外。**schema 自体のメタスキーマ検証も実施** (別ツール不要)
- **schema を `metadata-v1.1.schema.json` → `metadata-v1.3.schema.json` に改名** (中身は #488 で v1.3 化済、参照ゼロのため `git mv` のみ)
- **`test.yml` に検証ステップ追加** (実 24,407 件を毎回検証 = drift ゲート)
- **テスト 11 ケース** (適合/違反/不正JSON/不正schema/除外/exit code)

## 検証
- 実データ **24,407 件すべて適合** (= 現 schema は実装と完全一致)
- 全 **669 テスト pass** / カバレッジ100% / ruff・mypy・actionlint・pre-commit 全 pass

## 効果
今後、型定義を変えて schema 更新を忘れる (= #488 で起きた陳腐化) と CI が即座に検出します。監査で見つけた verify_metadata の quality ネスト不整合のような構造崩れも、この検証層が catch できます。

Source: [check-jsonschema](https://github.com/python-jsonschema/check-jsonschema)

🤖 Generated with [Claude Code](https://claude.com/claude-code)