### PR TITLE
chore(mise): .mise.toml で uv バージョンを 0.11.23 にピン

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -1,0 +1,8 @@
+# mise (https://mise.jdx.dev/) 用のツールバージョン定義
+#
+# Python は既存の .python-version (3.11) から解決されるため、ここでは uv のみ宣言する。
+# uv のバージョンが未宣言だと mise が "No version is set for shim: uv" で解決に失敗するため、
+# プロジェクトで使用する uv を固定する (再現性の確保)。
+# CI はこのファイルを参照せず astral-sh/setup-uv でセットアップするため影響しない。
+[tools]
+uv = "0.11.23"


### PR DESCRIPTION
## 概要

プロジェクトの uv バージョンを `.mise.toml` で `0.11.23` に固定します。

## 背景 / 動機

mise 管理環境でこのリポジトリ内から uv を呼ぶと、uv のバージョンが未宣言のため
mise が解決に失敗していました:

```
mise ERROR No version is set for shim: uv
```

Python は既存の `.python-version` (3.11) から解決される一方、uv はどの設定ファイルにも
宣言が無く、mise がバージョンを決定できないことが原因です。本 PR で uv を明示宣言し、
ツールチェーンの再現性を確保します。

## 変更内容

- `.mise.toml` を新規追加 (`[tools] uv = "0.11.23"`)
  - Python は `.python-version` で解決されるため uv のみ宣言 (最小変更)

## 動作確認

`.mise.toml` 追加後、これまで失敗していた解決が成功することを確認:

```
$ uv --version          # mise shim 経由
uv 0.11.23 (... aarch64-apple-darwin)
$ mise ls --current
uv  0.11.23  .../.mise.toml  0.11.23
```

## 影響範囲 / 補足

- **CI には影響しません**: ワークフローは `astral-sh/setup-uv` で uv をセットアップしており、
  本ファイルを参照しません。
- mise 非利用の開発者には影響しません (`.mise.toml` は無視されます)。
- 新規 `.mise.toml` は初回利用時に `mise trust` が必要です (mise の標準挙動)。
- **スコープ外**: 非対話シェルで mise の shims が PATH に無い件はローカルのシェル設定の
  問題であり、リポジトリでは解決できないため本 PR の対象外です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 開発環境ツール設定ファイル（`.mise.toml`）を追加し、ツールチェーンのバージョン管理を改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->