### PR TITLE
chore(deps): add 7-day Dependabot cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,9 @@ updates:
       day: "monday"
       time: "09:00"
       timezone: "Asia/Tokyo"
+    # Delay version-update PRs for supply-chain observation; security updates are exempt.
+    cooldown:
+      default-days: 7
     labels:
       - "dependencies"
       - "github-actions"
@@ -29,6 +32,9 @@ updates:
       day: "monday"
       time: "09:00"
       timezone: "Asia/Tokyo"
+    # Delay version-update PRs for supply-chain observation; security updates are exempt.
+    cooldown:
+      default-days: 7
     labels:
       - "dependencies"
       - "python"
@@ -80,6 +86,9 @@ updates:
       day: "monday"
       time: "09:00"
       timezone: "Asia/Tokyo"
+    # Delay version-update PRs for supply-chain observation; security updates are exempt.
+    cooldown:
+      default-days: 7
     labels:
       - "dependencies"
       - "pre-commit"

--- a/tests/test_dependabot_config.py
+++ b/tests/test_dependabot_config.py
@@ -1,0 +1,15 @@
+from pathlib import Path
+
+import yaml
+
+
+def test_all_dependabot_version_updates_have_seven_day_cooldown():
+    config = yaml.safe_load(Path(".github/dependabot.yml").read_text(encoding="utf-8"))
+
+    invalid_ecosystems = [
+        update["package-ecosystem"]
+        for update in config["updates"]
+        if update.get("cooldown", {}).get("default-days") != 7
+    ]
+
+    assert invalid_ecosystems == []

--- a/tests/test_dependabot_config.py
+++ b/tests/test_dependabot_config.py
@@ -4,7 +4,9 @@ import yaml
 
 
 def test_all_dependabot_version_updates_have_seven_day_cooldown():
-    config = yaml.safe_load(Path(".github/dependabot.yml").read_text(encoding="utf-8"))
+    project_root = Path(__file__).resolve().parent.parent
+    config_path = project_root / ".github" / "dependabot.yml"
+    config = yaml.safe_load(config_path.read_text(encoding="utf-8"))
 
     invalid_ecosystems = [
         update["package-ecosystem"]


### PR DESCRIPTION
## 概要

- GitHub Actions、uv、pre-commit のversion updateに7日間のDependabot cooldownを設定
- 全ecosystemでcooldownが維持されることを設定テストで保証

## 背景

公開直後の依存バージョンを取り込まず、サプライチェーン上の問題や初期regressionが判明する観察期間を確保します。

GitHub公式仕様上、cooldownはversion updateだけに適用され、security updateは遅延しません。

https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#cooldown

## 影響

- 通常の依存更新PRはリリースから7日経過後の定期実行で作成されます
- security update PRの作成タイミングは変わりません
- 現在open中の既存Dependabot PRには遡及しません

## 検証

- `uv run pytest`（670件成功）
- `uv run pre-commit run --all-files --show-diff-on-failure`
- commit時のpre-commit hook


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * 自動依存関係更新のPR作成に、7日間の遅延（cooldown）が追加されました。
  * セキュリティ更新は遅延の対象外として扱われます。
* **Tests**
  * 依存関係更新の設定で、すべての対象が7日設定であることを確認するテストを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->