### PR TITLE
fix(fetch): 設定したHTTPタイムアウトを全POSTへ反映

### DIFF
--- a/src/fetchers/base_fetcher.py
+++ b/src/fetchers/base_fetcher.py
@@ -109,7 +109,7 @@ class TokyoEpidemicSurveillanceFetcher:
         "20": "dlwzensu.do",  # 全数報告疾病
     }
 
-    def __init__(self, timeout: RequestTimeout = 30.0):
+    def __init__(self, timeout: RequestTimeout = 30.0) -> None:
         self.request_timeout = validate_request_timeout(timeout)
         self.session = requests.Session()
 

--- a/src/fetchers/base_fetcher.py
+++ b/src/fetchers/base_fetcher.py
@@ -2,9 +2,36 @@
 東京都感染症発生動向情報システムからデータを取得する基底クラス
 """
 
+import math
 from typing import ClassVar
 
 import requests
+
+RequestTimeout = float | tuple[float, float]
+
+
+def _validate_positive_timeout(value: object, *, name: str) -> float:
+    """Validate and normalize one timeout component."""
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise TypeError(f"{name} must be a number")
+
+    normalized = float(value)
+    if not math.isfinite(normalized) or normalized <= 0:
+        raise ValueError(f"{name} must be a finite positive number")
+    return normalized
+
+
+def validate_request_timeout(timeout: object) -> RequestTimeout:
+    """Validate a Requests-compatible scalar or (connect, read) timeout."""
+    if isinstance(timeout, tuple):
+        if len(timeout) != 2:
+            raise ValueError("timeout tuple must contain connect and read values")
+        return (
+            _validate_positive_timeout(timeout[0], name="connect timeout"),
+            _validate_positive_timeout(timeout[1], name="read timeout"),
+        )
+
+    return _validate_positive_timeout(timeout, name="timeout")
 
 
 class TokyoEpidemicSurveillanceFetcher:
@@ -82,7 +109,8 @@ class TokyoEpidemicSurveillanceFetcher:
         "20": "dlwzensu.do",  # 全数報告疾病
     }
 
-    def __init__(self):
+    def __init__(self, timeout: RequestTimeout = 30.0):
+        self.request_timeout = validate_request_timeout(timeout)
         self.session = requests.Session()
 
     def _post_request(
@@ -130,7 +158,7 @@ class TokyoEpidemicSurveillanceFetcher:
             "val(totalMode)": total_mode,
         }
 
-        response = self.session.post(url, data=data, timeout=30)
+        response = self.session.post(url, data=data, timeout=self.request_timeout)
 
         if response.status_code == 200:
             return response.content

--- a/src/fetchers/enhanced_fetcher.py
+++ b/src/fetchers/enhanced_fetcher.py
@@ -15,7 +15,7 @@ from typing import Any
 
 from requests.exceptions import ConnectionError, HTTPError, Timeout
 
-from .base_fetcher import TokyoEpidemicSurveillanceFetcher
+from .base_fetcher import RequestTimeout, TokyoEpidemicSurveillanceFetcher, validate_request_timeout
 
 # ロガー設定
 logger = logging.getLogger(__name__)
@@ -71,10 +71,13 @@ class DataFetcherConfig:
     max_retries: int = 3
     base_delay: float = 1.0
     max_delay: float = 60.0
-    timeout: int = 30
+    timeout: RequestTimeout = 30.0
     rate_limit_delay: float = 1.0
     enable_jitter: bool = True
     user_agent: str = "TokyoEpidemicDataFetcher/1.0 (GitHub Actions Automation)"
+
+    def __post_init__(self) -> None:
+        self.timeout = validate_request_timeout(self.timeout)
 
 
 class RetryHandler:
@@ -202,8 +205,8 @@ class EnhancedEpidemicDataFetcher(TokyoEpidemicSurveillanceFetcher):
     """拡張版感染症データフェッチャー"""
 
     def __init__(self, config: DataFetcherConfig | None = None):
-        super().__init__()
         self.config = config or DataFetcherConfig()
+        super().__init__(timeout=self.config.timeout)
         self.retry_handler = RetryHandler(self.config)
         self.rate_limiter = RateLimiter(self.config.rate_limit_delay)
 

--- a/tests/test_base_fetcher.py
+++ b/tests/test_base_fetcher.py
@@ -292,6 +292,7 @@ class TestTokyoEpidemicSurveillanceFetcher(unittest.TestCase):
         call_args = mock_post.call_args
         called_url = call_args[0][0]
         called_data = call_args[1]["data"]
+        called_timeout = call_args[1]["timeout"]
 
         # URLの検証 (dlwgender.doを含むこと)
         self.assertIn("dlwgender.do", called_url)
@@ -310,6 +311,18 @@ class TestTokyoEpidemicSurveillanceFetcher(unittest.TestCase):
             "val(totalMode)": "0",
         }
         self.assertEqual(called_data, expected_data)
+        self.assertEqual(called_timeout, 30)
+
+    @patch("src.fetchers.base_fetcher.requests.Session.post")
+    def test_custom_request_timeout_is_forwarded(self, mock_post):
+        """カスタムtimeoutが共通POST経路へ渡ることを確認"""
+        mock_response = Mock(status_code=200, content=b"test")
+        mock_post.return_value = mock_response
+        fetcher = TokyoEpidemicSurveillanceFetcher(timeout=(3.05, 27.0))
+
+        fetcher.fetch_csv_sentinel_weekly_gender()
+
+        self.assertEqual(mock_post.call_args.kwargs["timeout"], (3.05, 27.0))
 
 
 if __name__ == "__main__":

--- a/tests/test_enhanced_fetcher.py
+++ b/tests/test_enhanced_fetcher.py
@@ -9,7 +9,7 @@ from datetime import datetime
 from pathlib import Path
 from unittest.mock import AsyncMock, Mock, patch
 
-from requests.exceptions import ConnectionError
+from requests.exceptions import ConnectionError, Timeout
 
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
@@ -122,6 +122,42 @@ class TestEnhancedEpidemicDataFetcher(unittest.TestCase):
     def setUp(self):
         self.config = DataFetcherConfig(max_retries=2, base_delay=0.1, timeout=10, rate_limit_delay=0.1)
         self.fetcher = EnhancedEpidemicDataFetcher(self.config)
+
+    def test_request_timeout_validation(self):
+        """Requests互換の正数timeoutだけを受け入れることを確認"""
+        for timeout in (7, 0.5, (3.05, 27)):
+            with self.subTest(timeout=timeout):
+                self.assertEqual(DataFetcherConfig(timeout=timeout).timeout, timeout)
+
+        for timeout in (0, -1, float("inf"), (1, 0), (1,), (1, 2, 3)):
+            with self.subTest(timeout=timeout), self.assertRaises(ValueError):
+                DataFetcherConfig(timeout=timeout)
+
+        for timeout in (True, "30", (1, "2")):
+            with self.subTest(timeout=timeout), self.assertRaises(TypeError):
+                DataFetcherConfig(timeout=timeout)
+
+    @patch("src.fetchers.base_fetcher.requests.Session.post")
+    def test_all_fetch_methods_use_configured_timeout(self, mock_post):
+        """全データ種別のHTTP POSTが設定timeoutを共有することを確認"""
+        mock_post.return_value = Mock(status_code=200, content=b"test")
+
+        for data_type, fetch_method in self.fetcher.fetch_methods.items():
+            with self.subTest(data_type=data_type):
+                fetch_method()
+                self.assertEqual(mock_post.call_args.kwargs["timeout"], 10)
+
+    @patch("src.fetchers.base_fetcher.requests.Session.post")
+    def test_retry_preserves_configured_timeout(self, mock_post):
+        """リトライ後も同じtimeout設定がHTTP POSTへ渡ることを確認"""
+        mock_post.side_effect = [Timeout("timed out"), Mock(status_code=200, content=b"test")]
+
+        with patch("asyncio.sleep", new_callable=AsyncMock):
+            result = self.fetcher.fetch_with_retry(self.fetcher.fetch_csv_sentinel_weekly_gender)
+
+        self.assertTrue(result.success)
+        self.assertEqual(result.retry_count, 2)
+        self.assertEqual([call.kwargs["timeout"] for call in mock_post.call_args_list], [10, 10])
 
     @patch("src.fetchers.base_fetcher.requests.Session.post")
     def test_fetch_with_retry_success(self, mock_post):

--- a/tests/test_enhanced_fetcher.py
+++ b/tests/test_enhanced_fetcher.py
@@ -144,7 +144,9 @@ class TestEnhancedEpidemicDataFetcher(unittest.TestCase):
 
         for data_type, fetch_method in self.fetcher.fetch_methods.items():
             with self.subTest(data_type=data_type):
+                mock_post.reset_mock()
                 fetch_method()
+                mock_post.assert_called_once()
                 self.assertEqual(mock_post.call_args.kwargs["timeout"], 10)
 
     @patch("src.fetchers.base_fetcher.requests.Session.post")

--- a/tests/test_target_filtering.py
+++ b/tests/test_target_filtering.py
@@ -289,9 +289,9 @@ class TestTargetFiltering(unittest.TestCase):
         mock_storage_class.return_value = mock_storage
 
         # 無効な週番号を含むtarget_weeks
-        from src.fetchers.enhanced_fetcher import EnhancedEpidemicDataFetcher
+        from src.fetchers.enhanced_fetcher import DataFetcherConfig, EnhancedEpidemicDataFetcher
 
-        fetcher = EnhancedEpidemicDataFetcher(Mock())
+        fetcher = EnhancedEpidemicDataFetcher(DataFetcherConfig())
 
         # 無効な週番号(0と54)でValueErrorが発生することを確認
         with self.assertRaises(ValueError) as cm:
@@ -311,9 +311,9 @@ class TestTargetFiltering(unittest.TestCase):
         mock_storage_class.return_value = mock_storage
 
         # 無効な月番号を含むtarget_months
-        from src.fetchers.enhanced_fetcher import EnhancedEpidemicDataFetcher
+        from src.fetchers.enhanced_fetcher import DataFetcherConfig, EnhancedEpidemicDataFetcher
 
-        fetcher = EnhancedEpidemicDataFetcher(Mock())
+        fetcher = EnhancedEpidemicDataFetcher(DataFetcherConfig())
 
         # 無効な月番号(0と13)でValueErrorが発生することを確認
         with self.assertRaises(ValueError) as cm:

--- a/tests/test_year_boundary_handling.py
+++ b/tests/test_year_boundary_handling.py
@@ -12,9 +12,9 @@ import tempfile
 import unittest
 from datetime import date, timedelta
 from pathlib import Path
-from unittest.mock import MagicMock, Mock
+from unittest.mock import Mock
 
-from src.fetchers.enhanced_fetcher import EnhancedEpidemicDataFetcher
+from src.fetchers.enhanced_fetcher import DataFetcherConfig, EnhancedEpidemicDataFetcher
 from src.managers.storage_manager import StorageManager
 
 
@@ -87,8 +87,7 @@ class TestYearBoundaryDataFetching(unittest.TestCase):
 
     def setUp(self):
         """テスト用の設定"""
-        self.config = MagicMock()
-        self.config.get.return_value = {}
+        self.config = DataFetcherConfig()
         self.fetcher = EnhancedEpidemicDataFetcher(self.config)
         self.fetcher.session = Mock()
 


### PR DESCRIPTION
## 概要

`DataFetcherConfig.timeout` を共通HTTP POST経路へ反映し、設定値がハードコードされた30秒に置き換わっていた問題を修正します。

Closes #598

## 原因と影響

拡張fetcherが `DataFetcherConfig` を保持している一方、基底fetcherへtimeoutを渡しておらず、`session.post()` は常に `timeout=30` を使用していました。このため短いtimeoutによる早期失敗や、遅い環境向けの調整が機能していませんでした。

## 変更内容

- Requests互換の単一timeoutと `(connect, read)` timeoutを共通型として定義
- `bool`・文字列・0以下・非有限値・不正なタプルを初期化時に拒否
- 基底fetcherが検証済みtimeoutを保持し、すべてのPOSTで使用
- 拡張fetcherが `DataFetcherConfig.timeout` を基底fetcherへ伝播
- 9データ種別、既定30秒、カスタムタプル、リトライ後の値維持を回帰テストで検証
- timeout契約の厳格化に合わせ、テスト内の無効なMock設定を実設定へ置換

Requests 2.34.2公式仕様: https://requests.readthedocs.io/en/stable/user/advanced/#timeouts

## 検証

- `uv run pytest tests/ --cov=src --cov-report=term-missing --cov-branch --cov-fail-under=100 -q -p no:warnings`
  - 697 passed
  - statement/branch coverage 100%
- `uv run pre-commit run --files ...`
  - Ruff、Black、isort、mypyを含め全通過


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * リクエストタイムアウトを設定できるようになりました。
  * 接続・読み取りごとのタイムアウト指定にも対応しました。
* **バグ修正**
  * 指定したタイムアウトがデータ取得リクエストに正しく適用されるようになりました。
  * 無効なタイムアウト値を早期に検出し、適切なエラーを表示します。
* **テスト**
  * タイムアウト設定の適用と入力値検証に関するテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->