### PR TITLE
fix(ci): uv同期をlockfile固定でfail-closed化

### DIFF
--- a/.github/workflows/_fetch-data-common.yml
+++ b/.github/workflows/_fetch-data-common.yml
@@ -41,11 +41,6 @@ on:
         required: false
         type: string
         default: ""
-      verify_lockfile:
-        description: "uv.lockが最新かチェック"
-        required: false
-        type: boolean
-        default: false
       verify_continuity:
         description: "データ連続性を検証"
         required: false
@@ -116,10 +111,6 @@ jobs:
 
       - name: Setup Python
         run: uv python install 3.11
-
-      - name: Verify lockfile is up-to-date
-        if: inputs.verify_lockfile
-        run: uv lock --check
 
       - name: Install dependencies
         run: uv sync --locked
@@ -222,7 +213,7 @@ jobs:
           fi
           if [ "$CSV_COUNT" -gt 0 ]; then
             VALIDATION_REPORT_BEFORE="data/logs/validation_before_${FETCH_TIMESTAMP}.json"
-            if uv run validate-data data/raw --pattern "*.csv" --output "$VALIDATION_REPORT_BEFORE"; then
+            if uv run --locked validate-data data/raw --pattern "*.csv" --output "$VALIDATION_REPORT_BEFORE"; then
               echo "✅ 事前データ検証成功"
               echo "VALIDATION_BEFORE_SUCCESS=true" >> "$GITHUB_ENV"
             else
@@ -261,7 +252,7 @@ jobs:
           echo "Starting ${{ inputs.workflow_display_name }} at $FETCH_TIMESTAMP"
 
           # コマンドの構築
-          FETCH_CMD=(uv run fetch-data)
+          FETCH_CMD=(uv run --locked fetch-data)
 
           # 年範囲の指定
           FETCH_CMD+=(--start-year "$START_YEAR")
@@ -383,7 +374,7 @@ jobs:
             # データ処理の実行 (変更されたファイルのみ)
             # 配列を安全に展開してスペースを含むファイル名にも対応
             # 注: set -o pipefailにより、パイプ内のPythonスクリプトの終了コードが正しく伝播される
-            if uv run process-data --files "${CHANGED_RAW_FILES[@]}" 2>&1 | tee "data/logs/process_${FETCH_TIMESTAMP}.log"; then
+            if uv run --locked process-data --files "${CHANGED_RAW_FILES[@]}" 2>&1 | tee "data/logs/process_${FETCH_TIMESTAMP}.log"; then
               echo "✅ データ処理: 成功"
               {
                 echo "PROCESS_RESULT=success"
@@ -494,7 +485,7 @@ jobs:
           echo "取得したデータの検証..."
           VALIDATION_REPORT="data/logs/validation_${FETCH_TIMESTAMP}.json"
 
-          if uv run validate-data data/raw --pattern "*.csv" --output "$VALIDATION_REPORT"; then
+          if uv run --locked validate-data data/raw --pattern "*.csv" --output "$VALIDATION_REPORT"; then
             echo "✅ データ検証成功"
             echo "VALIDATION_SUCCESS=true" >> "$GITHUB_ENV"
           else
@@ -517,7 +508,7 @@ jobs:
           CONTINUITY_REPORT="$RUNNER_TEMP/continuity_${FETCH_TIMESTAMP}.json"
           CONTINUITY_VALID=false
 
-          if uv run check-missing data/raw \
+          if uv run --locked check-missing data/raw \
             --start-year "$START_YEAR" \
             --end-year "$END_YEAR" \
             --as-of "$CURRENT_DATE" \
@@ -539,7 +530,7 @@ jobs:
         if: inputs.dry_run != true
         run: |
           echo "📈 感染動向グラフを生成しています..."
-          uv run python scripts/generate_charts.py
+          uv run --locked python scripts/generate_charts.py
 
           # グラフファイルをステージング
           if ! git diff --quiet docs/images/; then
@@ -551,7 +542,7 @@ jobs:
         if: inputs.dry_run != true
         run: |
           echo "📊 README統計情報を更新しています..."
-          uv run python scripts/update_readme_stats.py
+          uv run --locked python scripts/update_readme_stats.py
 
           # 変更があればステージング
           if ! git diff --quiet README.md; then

--- a/.github/workflows/_fetch-data-common.yml
+++ b/.github/workflows/_fetch-data-common.yml
@@ -122,7 +122,7 @@ jobs:
         run: uv lock --check
 
       - name: Install dependencies
-        run: uv sync
+        run: uv sync --locked
 
       - name: Configure git
         run: |

--- a/.github/workflows/fetch-data.yml
+++ b/.github/workflows/fetch-data.yml
@@ -74,7 +74,6 @@ jobs:
       dry_run: ${{ inputs.dry_run || false }}
 
       # manual専用機能
-      verify_lockfile: true # manualのみuv lock --checkを実行
       verify_continuity: ${{ inputs.verify_continuity || false }}
       auto_merge: ${{ inputs.auto_merge || false }}
       force_merge_on_failure: ${{ inputs.force_merge_on_failure || false }}

--- a/.github/workflows/migrate-metadata.yml
+++ b/.github/workflows/migrate-metadata.yml
@@ -127,7 +127,7 @@ jobs:
         run: uv python install 3.11
 
       - name: Install dependencies
-        run: uv sync
+        run: uv sync --locked
 
       - name: Prepare parameters
         id: params

--- a/.github/workflows/migrate-metadata.yml
+++ b/.github/workflows/migrate-metadata.yml
@@ -68,7 +68,7 @@ jobs:
           # 前のコミットのファイルを一時的に取得
           git show HEAD^:src/models/metadata.py > /tmp/old_metadata.py 2>/dev/null || echo "" > /tmp/old_metadata.py
 
-          OLD_VERSION=$(uv run python -c "
+          OLD_VERSION=$(uv run --no-project python -c "
           import re
           try:
               content = open('/tmp/old_metadata.py').read()
@@ -77,7 +77,7 @@ jobs:
           except Exception:
               print('')
           ")
-          NEW_VERSION=$(uv run python -c "
+          NEW_VERSION=$(uv run --no-project python -c "
           import re
           try:
               content = open('src/models/metadata.py').read()
@@ -155,7 +155,7 @@ jobs:
               TARGET_VERSION="${{ needs.check-version-change.outputs.new_version }}"
             else
               # Pythonで堅牢にバージョンを抽出
-              TARGET_VERSION=$(uv run python -c "
+              TARGET_VERSION=$(uv run --locked python -c "
           import re
           import sys
           try:
@@ -194,7 +194,7 @@ jobs:
         id: dry_run
         run: |
           echo "=== Dry Run ==="
-          uv run migrate-metadata --dry-run --target-version "${{ steps.params.outputs.target_version }}" 2>&1 | tee dry_run.log
+          uv run --locked migrate-metadata --dry-run --target-version "${{ steps.params.outputs.target_version }}" 2>&1 | tee dry_run.log
 
           # マイグレーション対象があるか確認 (空の場合は0をデフォルト)
           # ログ形式: "2025-12-17 07:45:46 - INFO - Migrated:       7546"
@@ -208,7 +208,7 @@ jobs:
         if: steps.params.outputs.dry_run == 'false' && steps.dry_run.outputs.migrated_count != '0'
         run: |
           echo "=== Running Migration ==="
-          uv run migrate-metadata --target-version "${{ steps.params.outputs.target_version }}" --verbose
+          uv run --locked migrate-metadata --target-version "${{ steps.params.outputs.target_version }}" --verbose
 
       - name: Run verification
         id: verify
@@ -217,7 +217,7 @@ jobs:
           echo "=== Running Verification ==="
           # 検証を実行 (--verbose と --output-json を同時使用)
           # ログはstderr、JSONはstdoutに出力される
-          STATS=$(uv run verify-metadata --only-unverified --verbose --output-json)
+          STATS=$(uv run --locked verify-metadata --only-unverified --verbose --output-json)
 
           # jq で堅牢にパース
           VERIFIED=$(echo "$STATS" | jq -r '.verified // 0')

--- a/.github/workflows/process-data.yml
+++ b/.github/workflows/process-data.yml
@@ -54,10 +54,7 @@ jobs:
         run: uv python install 3.11
 
       - name: Install dependencies
-        run: uv sync
-
-      - name: Verify lockfile is up-to-date
-        run: uv lock --check
+        run: uv sync --locked
 
       - name: Configure git
         run: |

--- a/.github/workflows/process-data.yml
+++ b/.github/workflows/process-data.yml
@@ -120,7 +120,7 @@ jobs:
           echo "Starting data processing at $PROCESS_TIMESTAMP"
 
           # コマンドの構築
-          PROCESS_CMD=(uv run process-data)
+          PROCESS_CMD=(uv run --locked process-data)
 
           # ターゲットファイルの指定
           if [ -n "$TARGET_FILES" ]; then
@@ -217,7 +217,7 @@ jobs:
           echo "処理済みデータを検証しています..."
 
           # 検証スクリプトの実行 (processed データは UTF-8)
-          if uv run validate-data data/processed \
+          if uv run --locked validate-data data/processed \
               --encoding utf-8 \
               --format markdown \
               --output "data/logs/validation_report_${PROCESS_TIMESTAMP}.md"; then

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,7 +48,7 @@ jobs:
 
       - name: Run unit tests
         run: |
-          uv run pytest tests/ \
+          uv run --locked pytest tests/ \
             --cov=src \
             --cov-report=term-missing \
             --cov-report=html:coverage_html \
@@ -77,7 +77,7 @@ jobs:
 
       - name: Test dry run of main script
         run: |
-          uv run fetch-data \
+          uv run --locked fetch-data \
             --dry-run \
             --start-year 2025 \
             --end-year 2025 \
@@ -86,20 +86,20 @@ jobs:
 
       - name: Check deprecated CLI usage
         run: |
-          uv run python scripts/check_deprecated_cli_usage.py
+          uv run --locked python scripts/check_deprecated_cli_usage.py
 
       - name: Check script syntax
         run: |
-          uv run python -m py_compile src/cli/fetch_data.py
-          uv run python -m py_compile scripts/check_missing.py
-          uv run python -m py_compile src/fetchers/base_fetcher.py
-          uv run python -m py_compile src/fetchers/enhanced_fetcher.py
-          uv run python -m py_compile src/managers/config_manager.py
-          uv run python -m py_compile src/managers/storage_manager.py
+          uv run --locked python -m py_compile src/cli/fetch_data.py
+          uv run --locked python -m py_compile scripts/check_missing.py
+          uv run --locked python -m py_compile src/fetchers/base_fetcher.py
+          uv run --locked python -m py_compile src/fetchers/enhanced_fetcher.py
+          uv run --locked python -m py_compile src/managers/config_manager.py
+          uv run --locked python -m py_compile src/managers/storage_manager.py
 
       - name: Validate metadata against JSON Schema (v1.3.0)
         run: |
-          uv run python scripts/validate_metadata_schema.py
+          uv run --locked python scripts/validate_metadata_schema.py
 
       - name: Summary
         if: always()
@@ -142,16 +142,16 @@ jobs:
 
       - name: Run Ruff linter
         run: |
-          uv run ruff check src/ scripts/ tests/
+          uv run --locked ruff check src/ scripts/ tests/
 
       - name: Check black formatting
         run: |
-          uv run black --check --diff src/ scripts/ tests/ --line-length=120
+          uv run --locked black --check --diff src/ scripts/ tests/ --line-length=120
 
       - name: Check import sorting
         run: |
-          uv run isort --check-only --diff src/ scripts/ tests/
+          uv run --locked isort --check-only --diff src/ scripts/ tests/
 
       - name: Run mypy type checking
         run: |
-          uv run mypy src/ scripts/ --ignore-missing-imports --no-strict-optional
+          uv run --locked mypy src/ scripts/ --ignore-missing-imports --no-strict-optional

--- a/tests/test_auto_merge_gate.py
+++ b/tests/test_auto_merge_gate.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import shutil
 import subprocess
 from pathlib import Path
 
@@ -10,6 +11,48 @@ PROJECT_ROOT = Path(__file__).resolve().parent.parent
 GATE_SCRIPT = PROJECT_ROOT / "scripts" / "auto_merge_gate.sh"
 COMMON_WORKFLOW = PROJECT_ROOT / ".github" / "workflows" / "_fetch-data-common.yml"
 CREATE_PR_SCRIPT = PROJECT_ROOT / "scripts" / "create_pr.sh"
+WORKFLOW_DIRECTORY = PROJECT_ROOT / ".github" / "workflows"
+
+
+def test_workflows_install_from_the_committed_lockfile() -> None:
+    unlocked_syncs: list[str] = []
+
+    for workflow_path in sorted(WORKFLOW_DIRECTORY.glob("*.y*ml")):
+        for line_number, line in enumerate(workflow_path.read_text(encoding="utf-8").splitlines(), start=1):
+            command = line.strip()
+            if not command.startswith("#") and "uv sync" in command and "--locked" not in command.split():
+                unlocked_syncs.append(f"{workflow_path.name}:{line_number}: {command}")
+
+    assert unlocked_syncs == []
+
+
+def test_locked_sync_rejects_a_missing_lockfile(tmp_path: Path) -> None:
+    project_file = tmp_path / "pyproject.toml"
+    project_file.write_text(
+        """\
+[project]
+name = "missing-lockfile"
+version = "0.0.0"
+requires-python = ">=3.11"
+dependencies = []
+""",
+        encoding="utf-8",
+    )
+
+    env = os.environ.copy()
+    env.pop("VIRTUAL_ENV", None)
+    result = subprocess.run(
+        [shutil.which("uv") or "uv", "sync", "--locked"],
+        cwd=tmp_path,
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode != 0
+    assert "uv.lock" in result.stderr
+    assert "--locked" in result.stderr
 
 
 def evaluate_gate(

--- a/tests/test_auto_merge_gate.py
+++ b/tests/test_auto_merge_gate.py
@@ -14,12 +14,13 @@ GATE_SCRIPT = PROJECT_ROOT / "scripts" / "auto_merge_gate.sh"
 COMMON_WORKFLOW = PROJECT_ROOT / ".github" / "workflows" / "_fetch-data-common.yml"
 CREATE_PR_SCRIPT = PROJECT_ROOT / "scripts" / "create_pr.sh"
 WORKFLOW_DIRECTORY = PROJECT_ROOT / ".github" / "workflows"
-UV_SYNC_COMMAND = re.compile(r"^(?:if\s+)?(?:!\s+)?uv\s+sync(?:\s|$)")
+UV_PROJECT_COMMAND = re.compile(r"\buv\s+(sync|run)\b")
 LOCKED_OPTION = re.compile(r"(?:^|\s)--locked(?=$|[\s;&|])")
+NO_PROJECT_OPTION = re.compile(r"(?:^|\s)--no-project(?=$|[\s;&|])")
 
 
-def test_workflows_install_from_the_committed_lockfile() -> None:
-    unlocked_syncs: list[str] = []
+def test_workflow_project_commands_do_not_mutate_the_lockfile() -> None:
+    unguarded_commands: list[str] = []
 
     for workflow_path in sorted(WORKFLOW_DIRECTORY.glob("*.y*ml")):
         workflow = yaml.safe_load(workflow_path.read_text(encoding="utf-8"))
@@ -37,13 +38,22 @@ def test_workflows_install_from_the_committed_lockfile() -> None:
             for step in steps:
                 if not isinstance(step, dict) or not isinstance(step.get("run"), str):
                     continue
-                for line in step["run"].splitlines():
-                    command = line.strip()
-                    if UV_SYNC_COMMAND.match(command) and not LOCKED_OPTION.search(command):
+                script = re.sub(r"\\\s*\n\s*", " ", step["run"])
+                for line in script.splitlines():
+                    for command in re.split(r"&&|\|\||;", line):
+                        match = UV_PROJECT_COMMAND.search(command)
+                        if match is None:
+                            continue
+                        arguments = command[match.end() :]
+                        guarded = LOCKED_OPTION.search(arguments) is not None
+                        if match.group(1) == "run":
+                            guarded = guarded or NO_PROJECT_OPTION.search(arguments) is not None
+                        if guarded:
+                            continue
                         step_name = step.get("name", "unnamed step")
-                        unlocked_syncs.append(f"{workflow_path.name}:{job_name}:{step_name}: {command}")
+                        unguarded_commands.append(f"{workflow_path.name}:{job_name}:{step_name}: {command.strip()}")
 
-    assert unlocked_syncs == []
+    assert unguarded_commands == []
 
 
 def test_locked_sync_rejects_a_missing_lockfile(tmp_path: Path) -> None:
@@ -247,7 +257,7 @@ def test_common_workflow_captures_canonical_continuity_result() -> None:
     continuity_step = workflow[workflow.index("- name: Verify data continuity") :]
     continuity_step = continuity_step[: continuity_step.index("- name: Generate visualization charts")]
 
-    assert "uv run check-missing data/raw" in continuity_step
+    assert "uv run --locked check-missing data/raw" in continuity_step
     assert '--start-year "$START_YEAR"' in continuity_step
     assert '--end-year "$END_YEAR"' in continuity_step
     assert '--as-of "$CURRENT_DATE"' in continuity_step

--- a/tests/test_auto_merge_gate.py
+++ b/tests/test_auto_merge_gate.py
@@ -1,27 +1,47 @@
 from __future__ import annotations
 
 import os
+import re
 import shutil
 import subprocess
 from pathlib import Path
 
 import pytest
+import yaml
 
 PROJECT_ROOT = Path(__file__).resolve().parent.parent
 GATE_SCRIPT = PROJECT_ROOT / "scripts" / "auto_merge_gate.sh"
 COMMON_WORKFLOW = PROJECT_ROOT / ".github" / "workflows" / "_fetch-data-common.yml"
 CREATE_PR_SCRIPT = PROJECT_ROOT / "scripts" / "create_pr.sh"
 WORKFLOW_DIRECTORY = PROJECT_ROOT / ".github" / "workflows"
+UV_SYNC_COMMAND = re.compile(r"^(?:if\s+)?(?:!\s+)?uv\s+sync(?:\s|$)")
+LOCKED_OPTION = re.compile(r"(?:^|\s)--locked(?=$|[\s;&|])")
 
 
 def test_workflows_install_from_the_committed_lockfile() -> None:
     unlocked_syncs: list[str] = []
 
     for workflow_path in sorted(WORKFLOW_DIRECTORY.glob("*.y*ml")):
-        for line_number, line in enumerate(workflow_path.read_text(encoding="utf-8").splitlines(), start=1):
-            command = line.strip()
-            if not command.startswith("#") and "uv sync" in command and "--locked" not in command.split():
-                unlocked_syncs.append(f"{workflow_path.name}:{line_number}: {command}")
+        workflow = yaml.safe_load(workflow_path.read_text(encoding="utf-8"))
+        assert isinstance(workflow, dict)
+        jobs = workflow.get("jobs")
+        assert isinstance(jobs, dict)
+
+        for job_name, job in jobs.items():
+            if not isinstance(job, dict):
+                continue
+            steps = job.get("steps", [])
+            if not isinstance(steps, list):
+                continue
+
+            for step in steps:
+                if not isinstance(step, dict) or not isinstance(step.get("run"), str):
+                    continue
+                for line in step["run"].splitlines():
+                    command = line.strip()
+                    if UV_SYNC_COMMAND.match(command) and not LOCKED_OPTION.search(command):
+                        step_name = step.get("name", "unnamed step")
+                        unlocked_syncs.append(f"{workflow_path.name}:{job_name}:{step_name}: {command}")
 
     assert unlocked_syncs == []
 
@@ -52,7 +72,6 @@ dependencies = []
 
     assert result.returncode != 0
     assert "uv.lock" in result.stderr
-    assert "--locked" in result.stderr
 
 
 def evaluate_gate(


### PR DESCRIPTION
## 概要

CIおよび運用workflowの依存関係同期を `uv sync --locked` に統一し、コミットされた `uv.lock` と `pyproject.toml` が不整合な場合にfail-closedで停止するようにします。

Closes #596

## 原因と影響

通常の `uv sync` は同期前にlockfileを自動更新します。その後で `uv lock --check` を実行していたprocess workflowでは、古いlockfileが自己修復され、コミット漏れを検出できませんでした。共通fetchとmigrate workflowにもunlockedな同期が残っており、実行内容とレビュー対象のlockfileが一致しない可能性がありました。

## 変更内容

- 共通fetch、process、migrateの依存導入を `uv sync --locked` に統一
- project環境を使う全workflowの `uv run` を `--locked` に統一
- 依存関係不要のmigrate前段jobは `uv run --no-project` でproject lockから分離
- 意味を失った `verify_lockfile` 入力と重複する `uv lock --check` を削除
- 全workflowの `uv sync` / `uv run` がlockfileを変更しないことを回帰テストで検証
- `uv.lock` 欠落時に `uv sync --locked` が非0終了することを一時プロジェクトで検証

## 検証

- `uv sync --all-extras --locked`
- `git diff --exit-code -- uv.lock`
- `uv run pytest tests/ --cov=src --cov-report=term-missing --cov-branch --cov-fail-under=100 -q -p no:warnings`
  - 699 passed
  - statement/branch coverage 100%
- 変更対象4ファイルへの `uv run pre-commit run --files ...`
  - Ruff、Black、isort、mypy、actionlint/shellcheckを含め全通過

## 参考

- https://docs.astral.sh/uv/concepts/projects/sync/
