### PR TITLE
fix(cli): 処理カバー率をraw単位で正しく算出

### DIFF
--- a/src/cli/check_data_status.py
+++ b/src/cli/check_data_status.py
@@ -56,7 +56,11 @@ def main():
         sys.exit(1)
 
     # 各ディレクトリの状況を確認
-    status = check_status(data_dir, args.verbose)
+    try:
+        status = check_status(data_dir, args.verbose)
+    except OSError as exc:
+        print(f"❌ データディレクトリの読み取りに失敗しました: {exc}", file=sys.stderr)
+        sys.exit(1)
 
     if args.json:
         # JSON形式で出力
@@ -129,6 +133,10 @@ def check_processing_coverage(raw_dir: Path, processed_dir: Path) -> dict[str, A
 
     for raw_file in raw_files:
         raw_path = raw_file.relative_to(raw_dir).as_posix()
+        if raw_file.parent != raw_dir:
+            incomplete_sources.append({"raw_file": raw_path, "missing_outputs": [], "reason": "noncanonical_raw_path"})
+            continue
+
         output_variants = expected_processed_output_variants(raw_file.name)
         if output_variants is None:
             incomplete_sources.append(
@@ -235,6 +243,8 @@ def print_status(status: dict[str, Any], verbose: bool = False) -> None:
         for source in status["coverage"]["incomplete_sources"]:
             if source.get("reason") == "unsupported_raw_filename":
                 print(f"    - {source['raw_file']} (未対応のファイル名)")
+            elif source.get("reason") == "noncanonical_raw_path":
+                print(f"    - {source['raw_file']} (raw直下ではないファイル)")
             else:
                 missing = ", ".join(source["missing_outputs"])
                 print(f"    - {source['raw_file']} (欠損: {missing})")

--- a/src/cli/check_data_status.py
+++ b/src/cli/check_data_status.py
@@ -22,18 +22,18 @@ from typing import Any
 
 from src.cli.check_missing import FILENAME_PATTERN
 
-# Each raw dataset must have every listed normalized artifact before it is complete.
-# None means the normalized filename has no gender suffix.
-EXPECTED_OUTPUT_SUFFIXES: dict[str, tuple[str | None, ...]] = {
-    "notifiable_weekly": (None,),
-    "sentinel_weekly_gender": (None,),
-    "sentinel_weekly_age": ("male", "female", "total"),
-    "sentinel_weekly_health_center": ("male", "female", "total"),
-    "sentinel_weekly_medical_district": ("male", "female"),
-    "sentinel_monthly_gender": (None,),
-    "sentinel_monthly_age": ("male", "female", "total"),
-    "sentinel_monthly_health_center": ("male", "female", "total"),
-    "sentinel_monthly_medical_district": ("male", "female"),
+# A source is complete when every artifact in any one variant exists.
+# None represents the processor's successful unsuffixed output shape.
+EXPECTED_OUTPUT_SUFFIX_VARIANTS: dict[str, tuple[tuple[str | None, ...], ...]] = {
+    "notifiable_weekly": ((None,),),
+    "sentinel_weekly_gender": ((None,),),
+    "sentinel_weekly_age": (("male", "female", "total"), (None,)),
+    "sentinel_weekly_health_center": (("male", "female", "total"), (None,)),
+    "sentinel_weekly_medical_district": (("male", "female"), (None,)),
+    "sentinel_monthly_gender": ((None,),),
+    "sentinel_monthly_age": (("male", "female", "total"), (None,)),
+    "sentinel_monthly_health_center": (("male", "female", "total"), (None,)),
+    "sentinel_monthly_medical_district": (("male", "female"), (None,)),
 }
 
 
@@ -89,23 +89,32 @@ def check_status(data_dir: Path, verbose: bool = False) -> dict[str, Any]:
 
 
 def expected_processed_outputs(raw_filename: str) -> list[str] | None:
-    """Return the complete normalized artifact set for one canonical raw file."""
+    """Return the canonical normalized artifact set for one raw file."""
+    variants = expected_processed_output_variants(raw_filename)
+    return variants[0] if variants is not None else None
+
+
+def expected_processed_output_variants(raw_filename: str) -> list[list[str]] | None:
+    """Return every successful normalized artifact shape for one raw file."""
     match = FILENAME_PATTERN.fullmatch(raw_filename)
     if match is None:
         return None
 
     data_type = match.group("data_type")
-    suffixes = EXPECTED_OUTPUT_SUFFIXES.get(data_type)
-    if suffixes is None:
+    suffix_variants = EXPECTED_OUTPUT_SUFFIX_VARIANTS.get(data_type)
+    if suffix_variants is None:
         return None
 
     year = match.group("year")
     period = match.group("period")
-    outputs = []
-    for suffix in suffixes:
-        suffix_part = f"_{suffix}" if suffix is not None else ""
-        outputs.append(f"normalized_{data_type}{suffix_part}_{year}_{period}.csv")
-    return sorted(outputs)
+    output_variants = []
+    for suffixes in suffix_variants:
+        outputs = []
+        for suffix in suffixes:
+            suffix_part = f"_{suffix}" if suffix is not None else ""
+            outputs.append(f"normalized_{data_type}{suffix_part}_{year}_{period}.csv")
+        output_variants.append(sorted(outputs))
+    return output_variants
 
 
 def check_processing_coverage(raw_dir: Path, processed_dir: Path) -> dict[str, Any]:
@@ -120,19 +129,20 @@ def check_processing_coverage(raw_dir: Path, processed_dir: Path) -> dict[str, A
 
     for raw_file in raw_files:
         raw_path = raw_file.relative_to(raw_dir).as_posix()
-        expected_outputs = expected_processed_outputs(raw_file.name)
-        if expected_outputs is None:
+        output_variants = expected_processed_output_variants(raw_file.name)
+        if output_variants is None:
             incomplete_sources.append(
                 {"raw_file": raw_path, "missing_outputs": [], "reason": "unsupported_raw_filename"}
             )
             continue
 
-        expected_paths.update(expected_outputs)
-        missing_outputs = sorted(set(expected_outputs) - processed_paths)
-        if missing_outputs:
-            incomplete_sources.append({"raw_file": raw_path, "missing_outputs": missing_outputs})
-        else:
+        for outputs in output_variants:
+            expected_paths.update(outputs)
+        missing_variants = [sorted(set(outputs) - processed_paths) for outputs in output_variants]
+        if any(not missing_outputs for missing_outputs in missing_variants):
             processed_source_count += 1
+        else:
+            incomplete_sources.append({"raw_file": raw_path, "missing_outputs": missing_variants[0]})
 
     raw_source_count = len(raw_files)
     processed_rate = (processed_source_count / raw_source_count * 100) if raw_source_count else 0.0

--- a/src/cli/check_data_status.py
+++ b/src/cli/check_data_status.py
@@ -259,20 +259,31 @@ def print_status(status: dict[str, Any], verbose: bool = False) -> None:
     print("💡 推奨アクション")
     print("=" * 70)
 
+    processable_incomplete_sources = [
+        source for source in status["coverage"]["incomplete_sources"] if source.get("reason") is None
+    ]
+    unprocessable_sources = [
+        source for source in status["coverage"]["incomplete_sources"] if source.get("reason") is not None
+    ]
+
     if status["raw"]["file_count"] == 0:
         print("⚠️  data/raw/にデータがありません")
         print("   → データ取得スクリプトを実行してください")
 
-    elif status["coverage"]["processed_source_count"] == 0:
-        print("⚠️  データ処理が必要です")
-        print("   → uv run process-data --all")
-
-    elif status["coverage"]["incomplete_source_count"] > 0:
-        print("⚠️  一部のファイルが処理されていません")
-        print("   → uv run process-data --all")
-
     else:
-        print("✅ すべての処理が完了しています")
+        if processable_incomplete_sources:
+            if status["coverage"]["processed_source_count"] == 0:
+                print("⚠️  データ処理が必要です")
+            else:
+                print("⚠️  一部のファイルが処理されていません")
+            print("   → uv run process-data --all")
+
+        elif not unprocessable_sources:
+            print("✅ すべての処理が完了しています")
+
+        if unprocessable_sources:
+            print(f"⚠️  処理できないrawファイルが{len(unprocessable_sources)}件あります")
+            print("   → ファイル名または配置を修正してください")
 
     if status["coverage"]["orphaned_processed_count"] > 0:
         print("⚠️  rawに対応しない処理済みファイルを確認してください")

--- a/src/cli/check_data_status.py
+++ b/src/cli/check_data_status.py
@@ -21,19 +21,19 @@ from pathlib import Path
 from typing import Any
 
 from src.cli.check_missing import FILENAME_PATTERN
+from src.processors.data_processor import GENDER_SUFFIX_BY_LABEL, detect_gender_sections
 
-# A source is complete when every artifact in any one variant exists.
-# None represents the processor's successful unsuffixed output shape.
-EXPECTED_OUTPUT_SUFFIX_VARIANTS: dict[str, tuple[tuple[str | None, ...], ...]] = {
-    "notifiable_weekly": ((None,),),
-    "sentinel_weekly_gender": ((None,),),
-    "sentinel_weekly_age": (("male", "female", "total"), (None,)),
-    "sentinel_weekly_health_center": (("male", "female", "total"), (None,)),
-    "sentinel_weekly_medical_district": (("male", "female"), (None,)),
-    "sentinel_monthly_gender": ((None,),),
-    "sentinel_monthly_age": (("male", "female", "total"), (None,)),
-    "sentinel_monthly_health_center": (("male", "female", "total"), (None,)),
-    "sentinel_monthly_medical_district": (("male", "female"), (None,)),
+# Output expectations follow the processor's actual path for each data type.
+DATA_TYPE_OUTPUT_KINDS = {
+    "notifiable_weekly": "single",
+    "sentinel_weekly_gender": "gender_sections",
+    "sentinel_weekly_age": "gender_sections",
+    "sentinel_weekly_health_center": "gender_sections",
+    "sentinel_weekly_medical_district": "medical_district_sections",
+    "sentinel_monthly_gender": "gender_sections",
+    "sentinel_monthly_age": "gender_sections",
+    "sentinel_monthly_health_center": "gender_sections",
+    "sentinel_monthly_medical_district": "medical_district_sections",
 }
 
 
@@ -92,33 +92,38 @@ def check_status(data_dir: Path, verbose: bool = False) -> dict[str, Any]:
     return status
 
 
-def expected_processed_outputs(raw_filename: str) -> list[str] | None:
-    """Return the canonical normalized artifact set for one raw file."""
-    variants = expected_processed_output_variants(raw_filename)
-    return variants[0] if variants is not None else None
-
-
-def expected_processed_output_variants(raw_filename: str) -> list[list[str]] | None:
-    """Return every successful normalized artifact shape for one raw file."""
-    match = FILENAME_PATTERN.fullmatch(raw_filename)
+def expected_processed_outputs(raw_file: Path | str) -> list[str] | None:
+    """Return the normalized artifacts the processor can emit for one raw source."""
+    raw_path = Path(raw_file)
+    match = FILENAME_PATTERN.fullmatch(raw_path.name)
     if match is None:
         return None
 
     data_type = match.group("data_type")
-    suffix_variants = EXPECTED_OUTPUT_SUFFIX_VARIANTS.get(data_type)
-    if suffix_variants is None:
+    output_kind = DATA_TYPE_OUTPUT_KINDS.get(data_type)
+    if output_kind is None:
         return None
+
+    suffixes: list[str | None]
+    if output_kind == "single":
+        suffixes = [None]
+    else:
+        lines = raw_path.read_text(encoding="shift_jis", errors="replace").splitlines()
+        gender_sections = detect_gender_sections(lines)
+        if not gender_sections:
+            suffixes = [None]
+        else:
+            suffixes = list(dict.fromkeys(GENDER_SUFFIX_BY_LABEL[section["gender"]] for section in gender_sections))
+            if output_kind == "medical_district_sections":
+                suffixes = [suffix for suffix in suffixes if suffix != "total"]
 
     year = match.group("year")
     period = match.group("period")
-    output_variants = []
-    for suffixes in suffix_variants:
-        outputs = []
-        for suffix in suffixes:
-            suffix_part = f"_{suffix}" if suffix is not None else ""
-            outputs.append(f"normalized_{data_type}{suffix_part}_{year}_{period}.csv")
-        output_variants.append(sorted(outputs))
-    return output_variants
+    outputs = []
+    for suffix in suffixes:
+        suffix_part = f"_{suffix}" if suffix is not None else ""
+        outputs.append(f"normalized_{data_type}{suffix_part}_{year}_{period}.csv")
+    return sorted(outputs)
 
 
 def check_processing_coverage(raw_dir: Path, processed_dir: Path) -> dict[str, Any]:
@@ -137,20 +142,24 @@ def check_processing_coverage(raw_dir: Path, processed_dir: Path) -> dict[str, A
             incomplete_sources.append({"raw_file": raw_path, "missing_outputs": [], "reason": "noncanonical_raw_path"})
             continue
 
-        output_variants = expected_processed_output_variants(raw_file.name)
-        if output_variants is None:
+        expected_outputs = expected_processed_outputs(raw_file)
+        if expected_outputs is None:
             incomplete_sources.append(
                 {"raw_file": raw_path, "missing_outputs": [], "reason": "unsupported_raw_filename"}
             )
             continue
+        if not expected_outputs:
+            incomplete_sources.append(
+                {"raw_file": raw_path, "missing_outputs": [], "reason": "unsupported_gender_sections"}
+            )
+            continue
 
-        for outputs in output_variants:
-            expected_paths.update(outputs)
-        missing_variants = [sorted(set(outputs) - processed_paths) for outputs in output_variants]
-        if any(not missing_outputs for missing_outputs in missing_variants):
+        expected_paths.update(expected_outputs)
+        missing_outputs = sorted(set(expected_outputs) - processed_paths)
+        if not missing_outputs:
             processed_source_count += 1
         else:
-            incomplete_sources.append({"raw_file": raw_path, "missing_outputs": missing_variants[0]})
+            incomplete_sources.append({"raw_file": raw_path, "missing_outputs": missing_outputs})
 
     raw_source_count = len(raw_files)
     processed_rate = (processed_source_count / raw_source_count * 100) if raw_source_count else 0.0
@@ -245,6 +254,8 @@ def print_status(status: dict[str, Any], verbose: bool = False) -> None:
                 print(f"    - {source['raw_file']} (未対応のファイル名)")
             elif source.get("reason") == "noncanonical_raw_path":
                 print(f"    - {source['raw_file']} (raw直下ではないファイル)")
+            elif source.get("reason") == "unsupported_gender_sections":
+                print(f"    - {source['raw_file']} (処理可能な性別セクションなし)")
             else:
                 missing = ", ".join(source["missing_outputs"])
                 print(f"    - {source['raw_file']} (欠損: {missing})")
@@ -283,7 +294,10 @@ def print_status(status: dict[str, Any], verbose: bool = False) -> None:
 
         if unprocessable_sources:
             print(f"⚠️  処理できないrawファイルが{len(unprocessable_sources)}件あります")
-            print("   → ファイル名または配置を修正してください")
+            if any(source.get("reason") == "unsupported_gender_sections" for source in unprocessable_sources):
+                print("   → rawの性別セクションを修正してください")
+            if any(source.get("reason") != "unsupported_gender_sections" for source in unprocessable_sources):
+                print("   → ファイル名または配置を修正してください")
 
     if status["coverage"]["orphaned_processed_count"] > 0:
         print("⚠️  rawに対応しない処理済みファイルを確認してください")

--- a/src/cli/check_data_status.py
+++ b/src/cli/check_data_status.py
@@ -21,7 +21,11 @@ from pathlib import Path
 from typing import Any
 
 from src.cli.check_missing import FILENAME_PATTERN
-from src.processors.data_processor import GENDER_SUFFIX_BY_LABEL, detect_gender_sections
+from src.processors.data_processor import (
+    GENDER_SUFFIX_BY_LABEL,
+    detect_gender_sections,
+    extract_gender_section_data,
+)
 
 # Output expectations follow the processor's actual path for each data type.
 DATA_TYPE_OUTPUT_KINDS = {
@@ -113,7 +117,12 @@ def expected_processed_outputs(raw_file: Path | str) -> list[str] | None:
         if not gender_sections:
             suffixes = [None]
         else:
-            suffixes = list(dict.fromkeys(GENDER_SUFFIX_BY_LABEL[section["gender"]] for section in gender_sections))
+            processable_sections = [
+                section for section in gender_sections if extract_gender_section_data(lines, section)
+            ]
+            suffixes = list(
+                dict.fromkeys(GENDER_SUFFIX_BY_LABEL[section["gender"]] for section in processable_sections)
+            )
             if output_kind == "medical_district_sections":
                 suffixes = [suffix for suffix in suffixes if suffix != "total"]
 

--- a/src/cli/check_data_status.py
+++ b/src/cli/check_data_status.py
@@ -20,6 +20,22 @@ import sys
 from pathlib import Path
 from typing import Any
 
+from src.cli.check_missing import FILENAME_PATTERN
+
+# Each raw dataset must have every listed normalized artifact before it is complete.
+# None means the normalized filename has no gender suffix.
+EXPECTED_OUTPUT_SUFFIXES: dict[str, tuple[str | None, ...]] = {
+    "notifiable_weekly": (None,),
+    "sentinel_weekly_gender": (None,),
+    "sentinel_weekly_age": ("male", "female", "total"),
+    "sentinel_weekly_health_center": ("male", "female", "total"),
+    "sentinel_weekly_medical_district": ("male", "female"),
+    "sentinel_monthly_gender": (None,),
+    "sentinel_monthly_age": ("male", "female", "total"),
+    "sentinel_monthly_health_center": ("male", "female", "total"),
+    "sentinel_monthly_medical_district": ("male", "female"),
+}
+
 
 def main():
     """メイン処理"""
@@ -67,18 +83,70 @@ def check_status(data_dir: Path, verbose: bool = False) -> dict[str, Any]:
         "logs": check_directory(data_dir / "logs", verbose),
     }
 
-    # 処理カバー率を計算
-    if status["raw"]["file_count"] > 0:
-        processed_rate = (
-            (status["processed"]["file_count"] / status["raw"]["file_count"]) * 100
-            if status["processed"]["file_count"] > 0
-            else 0.0
-        )
-        status["coverage"] = {"processed_rate": processed_rate}
-    else:
-        status["coverage"] = {"processed_rate": 0.0}
+    status["coverage"] = check_processing_coverage(data_dir / "raw", data_dir / "processed")
 
     return status
+
+
+def expected_processed_outputs(raw_filename: str) -> list[str] | None:
+    """Return the complete normalized artifact set for one canonical raw file."""
+    match = FILENAME_PATTERN.fullmatch(raw_filename)
+    if match is None:
+        return None
+
+    data_type = match.group("data_type")
+    suffixes = EXPECTED_OUTPUT_SUFFIXES.get(data_type)
+    if suffixes is None:
+        return None
+
+    year = match.group("year")
+    period = match.group("period")
+    outputs = []
+    for suffix in suffixes:
+        suffix_part = f"_{suffix}" if suffix is not None else ""
+        outputs.append(f"normalized_{data_type}{suffix_part}_{year}_{period}.csv")
+    return sorted(outputs)
+
+
+def check_processing_coverage(raw_dir: Path, processed_dir: Path) -> dict[str, Any]:
+    """Calculate source-based processing coverage and identify mismatched artifacts."""
+    raw_files = sorted(raw_dir.rglob("*.csv")) if raw_dir.exists() else []
+    processed_files = sorted(processed_dir.rglob("*.csv")) if processed_dir.exists() else []
+    processed_paths = {path.relative_to(processed_dir).as_posix() for path in processed_files}
+
+    expected_paths: set[str] = set()
+    incomplete_sources: list[dict[str, Any]] = []
+    processed_source_count = 0
+
+    for raw_file in raw_files:
+        raw_path = raw_file.relative_to(raw_dir).as_posix()
+        expected_outputs = expected_processed_outputs(raw_file.name)
+        if expected_outputs is None:
+            incomplete_sources.append(
+                {"raw_file": raw_path, "missing_outputs": [], "reason": "unsupported_raw_filename"}
+            )
+            continue
+
+        expected_paths.update(expected_outputs)
+        missing_outputs = sorted(set(expected_outputs) - processed_paths)
+        if missing_outputs:
+            incomplete_sources.append({"raw_file": raw_path, "missing_outputs": missing_outputs})
+        else:
+            processed_source_count += 1
+
+    raw_source_count = len(raw_files)
+    processed_rate = (processed_source_count / raw_source_count * 100) if raw_source_count else 0.0
+    orphaned_processed_files = sorted(processed_paths - expected_paths)
+
+    return {
+        "processed_rate": processed_rate,
+        "raw_source_count": raw_source_count,
+        "processed_source_count": processed_source_count,
+        "incomplete_source_count": len(incomplete_sources),
+        "incomplete_sources": incomplete_sources,
+        "orphaned_processed_count": len(orphaned_processed_files),
+        "orphaned_processed_files": orphaned_processed_files,
+    }
 
 
 def check_directory(dir_path: Path, verbose: bool = False) -> dict[str, Any]:
@@ -146,6 +214,25 @@ def print_status(status: dict[str, Any], verbose: bool = False) -> None:
     print("📈 処理カバー率")
     print("=" * 70)
     print(f"処理済み率: {status['coverage']['processed_rate']:.1f}%")
+    print(
+        f"処理済みraw: {status['coverage']['processed_source_count']} / " f"{status['coverage']['raw_source_count']}件"
+    )
+    print(f"未完了raw: {status['coverage']['incomplete_source_count']}件")
+    print(f"rawに対応しない処理済みファイル: {status['coverage']['orphaned_processed_count']}件")
+
+    if verbose and status["coverage"]["incomplete_sources"]:
+        print("  未完了raw一覧:")
+        for source in status["coverage"]["incomplete_sources"]:
+            if source.get("reason") == "unsupported_raw_filename":
+                print(f"    - {source['raw_file']} (未対応のファイル名)")
+            else:
+                missing = ", ".join(source["missing_outputs"])
+                print(f"    - {source['raw_file']} (欠損: {missing})")
+
+    if verbose and status["coverage"]["orphaned_processed_files"]:
+        print("  孤立processed一覧:")
+        for path in status["coverage"]["orphaned_processed_files"]:
+            print(f"    - {path}")
 
     # 推奨アクション
     print("\n" + "=" * 70)
@@ -156,16 +243,19 @@ def print_status(status: dict[str, Any], verbose: bool = False) -> None:
         print("⚠️  data/raw/にデータがありません")
         print("   → データ取得スクリプトを実行してください")
 
-    elif status["processed"]["file_count"] == 0:
+    elif status["coverage"]["processed_source_count"] == 0:
         print("⚠️  データ処理が必要です")
         print("   → uv run process-data --all")
 
-    elif status["processed"]["file_count"] < status["raw"]["file_count"]:
+    elif status["coverage"]["incomplete_source_count"] > 0:
         print("⚠️  一部のファイルが処理されていません")
         print("   → uv run process-data --all")
 
     else:
         print("✅ すべての処理が完了しています")
+
+    if status["coverage"]["orphaned_processed_count"] > 0:
+        print("⚠️  rawに対応しない処理済みファイルを確認してください")
 
     print()
 

--- a/src/cli/check_data_status.py
+++ b/src/cli/check_data_status.py
@@ -16,6 +16,7 @@ Usage:
 
 import argparse
 import json
+import os
 import sys
 from pathlib import Path
 from typing import Any
@@ -23,8 +24,11 @@ from typing import Any
 from src.cli.check_missing import FILENAME_PATTERN
 from src.processors.data_processor import (
     GENDER_SUFFIX_BY_LABEL,
+    NOTIFIABLE_DATA_START_MARKERS,
+    SENTINEL_DATA_START_MARKERS,
     detect_gender_sections,
     extract_gender_section_data,
+    find_data_start_line,
 )
 
 # Output expectations follow the processor's actual path for each data type.
@@ -108,14 +112,14 @@ def expected_processed_outputs(raw_file: Path | str) -> list[str] | None:
     if output_kind is None:
         return None
 
+    lines = raw_path.read_text(encoding="shift_jis", errors="replace").splitlines()
     suffixes: list[str | None]
     if output_kind == "single":
-        suffixes = [None]
+        suffixes = [None] if find_data_start_line(lines, NOTIFIABLE_DATA_START_MARKERS) is not None else []
     else:
-        lines = raw_path.read_text(encoding="shift_jis", errors="replace").splitlines()
         gender_sections = detect_gender_sections(lines)
         if not gender_sections:
-            suffixes = [None]
+            suffixes = [None] if find_data_start_line(lines, SENTINEL_DATA_START_MARKERS) is not None else []
         else:
             processable_sections = [
                 section for section in gender_sections if extract_gender_section_data(lines, section)
@@ -135,10 +139,27 @@ def expected_processed_outputs(raw_file: Path | str) -> list[str] | None:
     return sorted(outputs)
 
 
+def _raise_scan_error(error: OSError) -> None:
+    raise error
+
+
+def find_csv_files(dir_path: Path) -> list[Path]:
+    """Find CSV files without suppressing directory traversal errors."""
+    if not dir_path.exists():
+        return []
+
+    return sorted(
+        Path(root) / filename
+        for root, _directories, filenames in os.walk(dir_path, onerror=_raise_scan_error)
+        for filename in filenames
+        if filename.endswith(".csv")
+    )
+
+
 def check_processing_coverage(raw_dir: Path, processed_dir: Path) -> dict[str, Any]:
     """Calculate source-based processing coverage and identify mismatched artifacts."""
-    raw_files = sorted(raw_dir.rglob("*.csv")) if raw_dir.exists() else []
-    processed_files = sorted(processed_dir.rglob("*.csv")) if processed_dir.exists() else []
+    raw_files = find_csv_files(raw_dir)
+    processed_files = find_csv_files(processed_dir)
     processed_paths = {path.relative_to(processed_dir).as_posix() for path in processed_files}
 
     expected_paths: set[str] = set()
@@ -159,7 +180,7 @@ def check_processing_coverage(raw_dir: Path, processed_dir: Path) -> dict[str, A
             continue
         if not expected_outputs:
             incomplete_sources.append(
-                {"raw_file": raw_path, "missing_outputs": [], "reason": "unsupported_gender_sections"}
+                {"raw_file": raw_path, "missing_outputs": [], "reason": "unprocessable_raw_content"}
             )
             continue
 
@@ -199,7 +220,7 @@ def check_directory(dir_path: Path, verbose: bool = False) -> dict[str, Any]:
         return {"exists": False, "file_count": 0, "total_size_mb": 0, "files": []}
 
     # CSVファイルを集計
-    csv_files = list(dir_path.rglob("*.csv"))
+    csv_files = find_csv_files(dir_path)
     total_size = sum(f.stat().st_size for f in csv_files)
 
     result: dict[str, Any] = {
@@ -263,8 +284,8 @@ def print_status(status: dict[str, Any], verbose: bool = False) -> None:
                 print(f"    - {source['raw_file']} (未対応のファイル名)")
             elif source.get("reason") == "noncanonical_raw_path":
                 print(f"    - {source['raw_file']} (raw直下ではないファイル)")
-            elif source.get("reason") == "unsupported_gender_sections":
-                print(f"    - {source['raw_file']} (処理可能な性別セクションなし)")
+            elif source.get("reason") == "unprocessable_raw_content":
+                print(f"    - {source['raw_file']} (処理可能なデータ構造なし)")
             else:
                 missing = ", ".join(source["missing_outputs"])
                 print(f"    - {source['raw_file']} (欠損: {missing})")
@@ -303,9 +324,9 @@ def print_status(status: dict[str, Any], verbose: bool = False) -> None:
 
         if unprocessable_sources:
             print(f"⚠️  処理できないrawファイルが{len(unprocessable_sources)}件あります")
-            if any(source.get("reason") == "unsupported_gender_sections" for source in unprocessable_sources):
-                print("   → rawの性別セクションを修正してください")
-            if any(source.get("reason") != "unsupported_gender_sections" for source in unprocessable_sources):
+            if any(source.get("reason") == "unprocessable_raw_content" for source in unprocessable_sources):
+                print("   → rawの内容を修正してください")
+            if any(source.get("reason") != "unprocessable_raw_content" for source in unprocessable_sources):
                 print("   → ファイル名または配置を修正してください")
 
     if status["coverage"]["orphaned_processed_count"] > 0:

--- a/src/processors/data_processor.py
+++ b/src/processors/data_processor.py
@@ -22,6 +22,16 @@ _GENDER_MALE = "男性"
 _GENDER_FEMALE = "女性"
 _GENDER_TOTAL = "男女合計"
 _GENDER_MARKER = "性別"
+_HEADER_SEARCH_RANGE = 20
+_DISEASE_KEYWORDS = [
+    "インフルエンザ",
+    "ウイルス",
+    "感染症",
+    "球菌",
+    "結膜",
+]
+_MIN_DISEASE_COUNT = 2
+_COMMENT_PREFIX = "*"
 
 GENDER_SUFFIX_BY_LABEL = {
     _GENDER_MALE: "male",
@@ -43,6 +53,35 @@ def detect_gender_sections(lines: list[str]) -> list[dict[str, Any]]:
                     sections.append({"gender": gender, "start_line": line_number})
 
     return sections
+
+
+def extract_gender_section_data(lines: list[str], section: dict[str, Any]) -> list[str]:
+    """Return the rows the processor can extract for one gender section."""
+    start_line = section["start_line"]
+    header_line = None
+    for line_number in range(start_line, min(start_line + _HEADER_SEARCH_RANGE, len(lines))):
+        line = lines[line_number]
+        disease_count = sum(1 for keyword in _DISEASE_KEYWORDS if keyword in line)
+        if disease_count >= _MIN_DISEASE_COUNT:
+            header_line = line_number
+            break
+
+    if header_line is None:
+        return []
+
+    data_lines = [lines[header_line]]
+    for line in lines[header_line + 1 :]:
+        if not line.strip():
+            continue
+        if _GENDER_MARKER in line or "定点報告" in line or "集計期間" in line:
+            break
+        if line.startswith(_COMMENT_PREFIX):
+            continue
+        data_lines.append(line)
+        if line.startswith('"合計"') or line.startswith("合計"):
+            break
+
+    return data_lines
 
 
 @dataclass
@@ -76,16 +115,10 @@ class DataProcessor:
     """データ処理を統合的に管理するクラス"""
 
     # クラス定数: マジックナンバー/ストリングを定数化
-    HEADER_SEARCH_RANGE = 20  # ヘッダー行を探す範囲(行数)
-    DISEASE_KEYWORDS: ClassVar[list[str]] = [
-        "インフルエンザ",
-        "ウイルス",
-        "感染症",
-        "球菌",
-        "結膜",
-    ]
-    MIN_DISEASE_COUNT = 2  # ヘッダー行と判定する最小疾病数
-    COMMENT_PREFIX = "*"  # 注釈行のプレフィックス
+    HEADER_SEARCH_RANGE = _HEADER_SEARCH_RANGE  # ヘッダー行を探す範囲(行数)
+    DISEASE_KEYWORDS: ClassVar[list[str]] = _DISEASE_KEYWORDS
+    MIN_DISEASE_COUNT = _MIN_DISEASE_COUNT  # ヘッダー行と判定する最小疾病数
+    COMMENT_PREFIX = _COMMENT_PREFIX  # 注釈行のプレフィックス
     GENDER_MALE = _GENDER_MALE
     GENDER_FEMALE = _GENDER_FEMALE
     GENDER_TOTAL = _GENDER_TOTAL
@@ -483,45 +516,7 @@ class DataProcessor:
         Returns:
             セクションのデータ行
         """
-        start_idx = section["start_line"]
-
-        # ヘッダー行を探す(疾病名が複数含まれる行)
-        header_idx = None
-        for i in range(start_idx, min(start_idx + self.HEADER_SEARCH_RANGE, len(lines))):
-            line = lines[i]
-            disease_count = sum(1 for keyword in self.DISEASE_KEYWORDS if keyword in line)
-            if disease_count >= self.MIN_DISEASE_COUNT:
-                header_idx = i
-                break
-
-        if header_idx is None:
-            return []
-
-        # データ行を抽出
-        data_lines = [lines[header_idx]]
-
-        for i in range(header_idx + 1, len(lines)):
-            line = lines[i]
-
-            # 空行や次のセクションのメタデータで終了
-            if not line.strip():
-                continue
-
-            if self.GENDER_MARKER in line or "定点報告" in line or "集計期間" in line:
-                break
-
-            # 注釈行をスキップ
-            if line.startswith(self.COMMENT_PREFIX):
-                continue
-
-            # データ行を追加
-            data_lines.append(line)
-
-            # 合計行で終了
-            if line.startswith('"合計"') or line.startswith("合計"):
-                break
-
-        return data_lines
+        return extract_gender_section_data(lines, section)
 
     def _get_gender_suffix(self, gender: str) -> str:
         """性別表示名をファイル名サフィックスに変換

--- a/src/processors/data_processor.py
+++ b/src/processors/data_processor.py
@@ -33,6 +33,9 @@ _DISEASE_KEYWORDS = [
 _MIN_DISEASE_COUNT = 2
 _COMMENT_PREFIX = "*"
 
+NOTIFIABLE_DATA_START_MARKERS = ("疾病名", "病名")
+SENTINEL_DATA_START_MARKERS = (*NOTIFIABLE_DATA_START_MARKERS, "年齢区分")
+
 GENDER_SUFFIX_BY_LABEL = {
     _GENDER_MALE: "male",
     _GENDER_FEMALE: "female",
@@ -82,6 +85,14 @@ def extract_gender_section_data(lines: list[str], section: dict[str, Any]) -> li
             break
 
     return data_lines
+
+
+def find_data_start_line(lines: list[str], markers: tuple[str, ...]) -> int | None:
+    """Return the first line containing one of the processor's data markers."""
+    for line_number, line in enumerate(lines):
+        if any(marker in line for marker in markers):
+            return line_number
+    return None
 
 
 @dataclass
@@ -229,11 +240,7 @@ class DataProcessor:
             output_file = self.processed_dir / output_filename
 
             # データ開始行を探す
-            data_start_idx = None
-            for i, line in enumerate(lines):
-                if "疾病名" in line or "病名" in line:
-                    data_start_idx = i
-                    break
+            data_start_idx = find_data_start_line(lines, NOTIFIABLE_DATA_START_MARKERS)
 
             if data_start_idx is None:
                 return NormalizationResult(success=False, error="データ開始行が見つかりません")
@@ -428,11 +435,7 @@ class DataProcessor:
             output_file = self.processed_dir / output_filename
 
             # データ開始行を探す
-            data_start_idx = None
-            for i, line in enumerate(lines):
-                if "疾病名" in line or "病名" in line or "年齢区分" in line:
-                    data_start_idx = i
-                    break
+            data_start_idx = find_data_start_line(lines, SENTINEL_DATA_START_MARKERS)
 
             if data_start_idx is None:
                 return NormalizationResult(success=False, error="データ開始行が見つかりません")

--- a/src/processors/data_processor.py
+++ b/src/processors/data_processor.py
@@ -18,6 +18,32 @@ from src.validators.quality_validator import QualityValidator
 
 logger = logging.getLogger(__name__)
 
+_GENDER_MALE = "男性"
+_GENDER_FEMALE = "女性"
+_GENDER_TOTAL = "男女合計"
+_GENDER_MARKER = "性別"
+
+GENDER_SUFFIX_BY_LABEL = {
+    _GENDER_MALE: "male",
+    _GENDER_FEMALE: "female",
+    _GENDER_TOTAL: "total",
+}
+
+
+def detect_gender_sections(lines: list[str]) -> list[dict[str, Any]]:
+    """Return gender section markers recognized by the processor."""
+    sections = []
+
+    for line_number, line in enumerate(lines):
+        if _GENDER_MARKER in line and "," in line:
+            parts = [part.strip().strip('"') for part in line.split(",")]
+            if len(parts) >= 2:
+                gender = parts[1]
+                if gender in GENDER_SUFFIX_BY_LABEL:
+                    sections.append({"gender": gender, "start_line": line_number})
+
+    return sections
+
 
 @dataclass
 class ConversionResult:
@@ -60,10 +86,10 @@ class DataProcessor:
     ]
     MIN_DISEASE_COUNT = 2  # ヘッダー行と判定する最小疾病数
     COMMENT_PREFIX = "*"  # 注釈行のプレフィックス
-    GENDER_MALE = "男性"
-    GENDER_FEMALE = "女性"
-    GENDER_TOTAL = "男女合計"
-    GENDER_MARKER = "性別"
+    GENDER_MALE = _GENDER_MALE
+    GENDER_FEMALE = _GENDER_FEMALE
+    GENDER_TOTAL = _GENDER_TOTAL
+    GENDER_MARKER = _GENDER_MARKER
 
     def __init__(self, base_dir: Path):
         """DataProcessorを初期化する。
@@ -406,17 +432,7 @@ class DataProcessor:
         Returns:
             性別セクション情報のリスト
         """
-        sections = []
-
-        for i, line in enumerate(lines):
-            if self.GENDER_MARKER in line and "," in line:
-                parts = [p.strip().strip('"') for p in line.split(",")]
-                if len(parts) >= 2:
-                    gender = parts[1]
-                    if gender in [self.GENDER_MALE, self.GENDER_FEMALE, self.GENDER_TOTAL]:
-                        sections.append({"gender": gender, "start_line": i})
-
-        return sections
+        return detect_gender_sections(lines)
 
     def _save_gender_section(self, lines: list[str], section: dict[str, Any], metadata: dict[str, Any]) -> Path | None:
         """性別セクションを保存
@@ -516,8 +532,7 @@ class DataProcessor:
         Returns:
             ファイル名サフィックス(male/female/total)
         """
-        mapping = {self.GENDER_MALE: "male", self.GENDER_FEMALE: "female", self.GENDER_TOTAL: "total"}
-        return mapping.get(gender, "unknown")
+        return GENDER_SUFFIX_BY_LABEL.get(gender, "unknown")
 
     def _extract_metadata_from_filename(self, filename: str) -> dict[str, Any] | None:
         """ファイル名からメタデータを抽出

--- a/tests/test_issue300_phase0_cli_core_coverage.py
+++ b/tests/test_issue300_phase0_cli_core_coverage.py
@@ -23,9 +23,27 @@ def _write_csv(path: Path, rows: list[str]) -> None:
     path.write_text("\n".join(rows) + "\n", encoding="utf-8")
 
 
+def _write_raw_csv(path: Path, rows: list[str]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(rows) + "\n", encoding="shift_jis")
+
+
+def _write_sectioned_raw(path: Path, genders: tuple[str, ...] = ("男性", "女性", "男女合計")) -> None:
+    rows = []
+    for gender in genders:
+        rows.extend(
+            [
+                f'性別,"{gender}"',
+                "年齢区分,インフルエンザ,RSウイルス",
+                "0歳,10,5",
+            ]
+        )
+    _write_raw_csv(path, rows)
+
+
 def test_check_data_status_directory_and_status_flow(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
     data_dir = tmp_path / "data"
-    _write_csv(data_dir / "raw" / "sentinel_weekly_age_2025_01.csv", ["h1,h2", "1,2"])
+    _write_sectioned_raw(data_dir / "raw" / "sentinel_weekly_age_2025_01.csv")
     for gender in ("male", "female", "total"):
         _write_csv(
             data_dir / "processed" / f"normalized_sentinel_weekly_age_{gender}_2025_01.csv",
@@ -74,7 +92,7 @@ def test_check_data_status_directory_and_status_flow(tmp_path: Path, capsys: pyt
     partial_dir = tmp_path / "partial"
     _write_csv(partial_dir / "raw" / "notifiable_weekly_2025_01.csv", ["h1,h2", "1,2"])
     _write_csv(partial_dir / "processed" / "normalized_notifiable_weekly_2025_01.csv", ["h1,h2", "1,2"])
-    _write_csv(partial_dir / "raw" / "sentinel_weekly_age_2025_02.csv", ["h1,h2", "1,2"])
+    _write_sectioned_raw(partial_dir / "raw" / "sentinel_weekly_age_2025_02.csv")
     for gender in ("male", "female"):
         _write_csv(
             partial_dir / "processed" / f"normalized_sentinel_weekly_age_{gender}_2025_02.csv",
@@ -120,6 +138,32 @@ def test_check_data_status_marks_unsupported_raw_as_incomplete(
     out = capsys.readouterr().out
     assert "invalid.csv (未対応のファイル名)" in out
     assert "ファイル名または配置を修正してください" in out
+    assert "uv run process-data --all" not in out
+
+
+def test_check_data_status_marks_unprocessable_medical_district_as_incomplete(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    data_dir = tmp_path / "data"
+    _write_sectioned_raw(
+        data_dir / "raw" / "sentinel_weekly_medical_district_2025_01.csv",
+        ("男女合計",),
+    )
+
+    status = cds.check_status(data_dir)
+
+    assert status["coverage"]["processed_rate"] == 0.0
+    assert status["coverage"]["incomplete_sources"] == [
+        {
+            "raw_file": "sentinel_weekly_medical_district_2025_01.csv",
+            "missing_outputs": [],
+            "reason": "unsupported_gender_sections",
+        }
+    ]
+    cds.print_status(status, verbose=True)
+    out = capsys.readouterr().out
+    assert "処理可能な性別セクションなし" in out
+    assert "rawの性別セクションを修正してください" in out
     assert "uv run process-data --all" not in out
 
 
@@ -200,8 +244,16 @@ def test_check_data_status_rejects_nested_raw_sources(tmp_path: Path, capsys: py
         ),
     ],
 )
-def test_check_data_status_defines_expected_outputs_per_data_type(raw_name: str, expected_outputs: list[str]) -> None:
-    assert cds.expected_processed_outputs(raw_name) == expected_outputs
+def test_check_data_status_defines_expected_outputs_per_data_type(
+    tmp_path: Path, raw_name: str, expected_outputs: list[str]
+) -> None:
+    raw_file = tmp_path / raw_name
+    if any("_male_" in output for output in expected_outputs):
+        _write_sectioned_raw(raw_file)
+    else:
+        _write_csv(raw_file, ["h1,h2", "1,2"])
+
+    assert cds.expected_processed_outputs(raw_file) == expected_outputs
 
 
 @pytest.mark.parametrize(
@@ -219,6 +271,22 @@ def test_check_data_status_accepts_unsuffixed_sentinel_fallback(tmp_path: Path, 
     data_dir = tmp_path / "data"
     _write_csv(data_dir / "raw" / f"{data_type}_2025_01.csv", ["h1,h2", "1,2"])
     _write_csv(data_dir / "processed" / f"normalized_{data_type}_2025_01.csv", ["h1,h2", "1,2"])
+
+    coverage = cds.check_status(data_dir)["coverage"]
+
+    assert coverage["processed_rate"] == 100.0
+    assert coverage["incomplete_sources"] == []
+    assert coverage["orphaned_processed_files"] == []
+
+
+def test_check_data_status_accepts_only_gender_sections_present_in_raw(tmp_path: Path) -> None:
+    data_dir = tmp_path / "data"
+    _write_sectioned_raw(data_dir / "raw" / "sentinel_weekly_age_2025_01.csv", ("男性", "女性"))
+    for gender in ("male", "female"):
+        _write_csv(
+            data_dir / "processed" / f"normalized_sentinel_weekly_age_{gender}_2025_01.csv",
+            ["h1,h2", "1,2"],
+        )
 
     coverage = cds.check_status(data_dir)["coverage"]
 

--- a/tests/test_issue300_phase0_cli_core_coverage.py
+++ b/tests/test_issue300_phase0_cli_core_coverage.py
@@ -115,6 +115,7 @@ def test_check_data_status_marks_unsupported_raw_as_incomplete(
         "normalized_invalid.csv",
         "normalized_unknown_2025_01.csv",
     ]
+    assert cds.expected_processed_outputs("invalid.csv") is None
     cds.print_status(status, verbose=True)
     assert "invalid.csv (未対応のファイル名)" in capsys.readouterr().out
 
@@ -175,6 +176,29 @@ def test_check_data_status_marks_unsupported_raw_as_incomplete(
 )
 def test_check_data_status_defines_expected_outputs_per_data_type(raw_name: str, expected_outputs: list[str]) -> None:
     assert cds.expected_processed_outputs(raw_name) == expected_outputs
+
+
+@pytest.mark.parametrize(
+    "data_type",
+    [
+        "sentinel_weekly_age",
+        "sentinel_weekly_health_center",
+        "sentinel_weekly_medical_district",
+        "sentinel_monthly_age",
+        "sentinel_monthly_health_center",
+        "sentinel_monthly_medical_district",
+    ],
+)
+def test_check_data_status_accepts_unsuffixed_sentinel_fallback(tmp_path: Path, data_type: str) -> None:
+    data_dir = tmp_path / "data"
+    _write_csv(data_dir / "raw" / f"{data_type}_2025_01.csv", ["h1,h2", "1,2"])
+    _write_csv(data_dir / "processed" / f"normalized_{data_type}_2025_01.csv", ["h1,h2", "1,2"])
+
+    coverage = cds.check_status(data_dir)["coverage"]
+
+    assert coverage["processed_rate"] == 100.0
+    assert coverage["incomplete_sources"] == []
+    assert coverage["orphaned_processed_files"] == []
 
 
 def test_check_data_status_print_dir_and_main(

--- a/tests/test_issue300_phase0_cli_core_coverage.py
+++ b/tests/test_issue300_phase0_cli_core_coverage.py
@@ -117,7 +117,10 @@ def test_check_data_status_marks_unsupported_raw_as_incomplete(
     ]
     assert cds.expected_processed_outputs("invalid.csv") is None
     cds.print_status(status, verbose=True)
-    assert "invalid.csv (未対応のファイル名)" in capsys.readouterr().out
+    out = capsys.readouterr().out
+    assert "invalid.csv (未対応のファイル名)" in out
+    assert "ファイル名または配置を修正してください" in out
+    assert "uv run process-data --all" not in out
 
 
 def test_check_data_status_rejects_nested_raw_sources(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
@@ -137,7 +140,10 @@ def test_check_data_status_rejects_nested_raw_sources(tmp_path: Path, capsys: py
     ]
     assert coverage["orphaned_processed_files"] == ["normalized_notifiable_weekly_2025_01.csv"]
     cds.print_status(status, verbose=True)
-    assert "a/notifiable_weekly_2025_01.csv (raw直下ではないファイル)" in capsys.readouterr().out
+    out = capsys.readouterr().out
+    assert "a/notifiable_weekly_2025_01.csv (raw直下ではないファイル)" in out
+    assert "ファイル名または配置を修正してください" in out
+    assert "uv run process-data --all" not in out
 
 
 @pytest.mark.parametrize(

--- a/tests/test_issue300_phase0_cli_core_coverage.py
+++ b/tests/test_issue300_phase0_cli_core_coverage.py
@@ -83,14 +83,14 @@ def test_check_data_status_directory_and_status_flow(tmp_path: Path, capsys: pyt
     assert "data/raw/にデータがありません" in out
 
     need_processing_dir = tmp_path / "need-processing"
-    _write_csv(need_processing_dir / "raw" / "notifiable_weekly_2025_01.csv", ["h1,h2", "1,2"])
+    _write_raw_csv(need_processing_dir / "raw" / "notifiable_weekly_2025_01.csv", ["疾病名,報告数", "病気,1"])
     status_need_processing = cds.check_status(need_processing_dir)
     cds.print_status(status_need_processing, verbose=False)
     out = capsys.readouterr().out
     assert "データ処理が必要です" in out
 
     partial_dir = tmp_path / "partial"
-    _write_csv(partial_dir / "raw" / "notifiable_weekly_2025_01.csv", ["h1,h2", "1,2"])
+    _write_raw_csv(partial_dir / "raw" / "notifiable_weekly_2025_01.csv", ["疾病名,報告数", "病気,1"])
     _write_csv(partial_dir / "processed" / "normalized_notifiable_weekly_2025_01.csv", ["h1,h2", "1,2"])
     _write_sectioned_raw(partial_dir / "raw" / "sentinel_weekly_age_2025_02.csv")
     for gender in ("male", "female"):
@@ -157,13 +157,13 @@ def test_check_data_status_marks_unprocessable_medical_district_as_incomplete(
         {
             "raw_file": "sentinel_weekly_medical_district_2025_01.csv",
             "missing_outputs": [],
-            "reason": "unsupported_gender_sections",
+            "reason": "unprocessable_raw_content",
         }
     ]
     cds.print_status(status, verbose=True)
     out = capsys.readouterr().out
-    assert "処理可能な性別セクションなし" in out
-    assert "rawの性別セクションを修正してください" in out
+    assert "処理可能なデータ構造なし" in out
+    assert "rawの内容を修正してください" in out
     assert "uv run process-data --all" not in out
 
 
@@ -250,8 +250,10 @@ def test_check_data_status_defines_expected_outputs_per_data_type(
     raw_file = tmp_path / raw_name
     if any("_male_" in output for output in expected_outputs):
         _write_sectioned_raw(raw_file)
+    elif raw_name.startswith("sentinel_"):
+        _write_raw_csv(raw_file, ["年齢区分,男性,女性", "0歳,1,2"])
     else:
-        _write_csv(raw_file, ["h1,h2", "1,2"])
+        _write_raw_csv(raw_file, ["疾病名,報告数", "病気,1"])
 
     assert cds.expected_processed_outputs(raw_file) == expected_outputs
 
@@ -269,7 +271,7 @@ def test_check_data_status_defines_expected_outputs_per_data_type(
 )
 def test_check_data_status_accepts_unsuffixed_sentinel_fallback(tmp_path: Path, data_type: str) -> None:
     data_dir = tmp_path / "data"
-    _write_csv(data_dir / "raw" / f"{data_type}_2025_01.csv", ["h1,h2", "1,2"])
+    _write_raw_csv(data_dir / "raw" / f"{data_type}_2025_01.csv", ["年齢区分,男性,女性", "0歳,1,2"])
     _write_csv(data_dir / "processed" / f"normalized_{data_type}_2025_01.csv", ["h1,h2", "1,2"])
 
     coverage = cds.check_status(data_dir)["coverage"]
@@ -277,6 +279,22 @@ def test_check_data_status_accepts_unsuffixed_sentinel_fallback(tmp_path: Path, 
     assert coverage["processed_rate"] == 100.0
     assert coverage["incomplete_sources"] == []
     assert coverage["orphaned_processed_files"] == []
+
+
+@pytest.mark.parametrize(
+    "raw_name",
+    ["notifiable_weekly_2025_01.csv", "sentinel_weekly_gender_2025_01.csv"],
+)
+def test_check_data_status_marks_missing_data_start_line_as_unprocessable(tmp_path: Path, raw_name: str) -> None:
+    data_dir = tmp_path / "data"
+    _write_raw_csv(data_dir / "raw" / raw_name, ["h1,h2", "1,2"])
+
+    coverage = cds.check_status(data_dir)["coverage"]
+
+    assert coverage["processed_rate"] == 0.0
+    assert coverage["incomplete_sources"] == [
+        {"raw_file": raw_name, "missing_outputs": [], "reason": "unprocessable_raw_content"}
+    ]
 
 
 def test_check_data_status_accepts_only_gender_sections_present_in_raw(tmp_path: Path) -> None:
@@ -332,7 +350,7 @@ def test_check_data_status_print_dir_and_main(
     assert "他 1件" in out
 
     data_dir = tmp_path / "d"
-    _write_csv(data_dir / "raw" / "notifiable_weekly_2025_01.csv", ["h1,h2", "1,2"])
+    _write_raw_csv(data_dir / "raw" / "notifiable_weekly_2025_01.csv", ["疾病名,報告数", "病気,1"])
     _write_csv(data_dir / "processed" / "normalized_notifiable_weekly_2025_01.csv", ["h1,h2", "1,2"])
 
     monkeypatch.setattr(sys, "argv", ["check-data-status", "--data-dir", str(data_dir), "--json"])
@@ -371,6 +389,18 @@ def test_check_data_status_main_reports_scan_error(
 
     assert exc.value.code == 1
     assert "データディレクトリの読み取りに失敗しました: permission denied" in capsys.readouterr().err
+
+
+def test_check_data_status_csv_scan_propagates_walk_error(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    def fail_walk(_root: Path, *, onerror: object):
+        assert callable(onerror)
+        onerror(PermissionError("permission denied"))
+        return []
+
+    monkeypatch.setattr(cds.os, "walk", fail_walk)
+
+    with pytest.raises(PermissionError, match="permission denied"):
+        cds.find_csv_files(tmp_path)
 
 
 def test_check_missing_main_paths(

--- a/tests/test_issue300_phase0_cli_core_coverage.py
+++ b/tests/test_issue300_phase0_cli_core_coverage.py
@@ -120,6 +120,26 @@ def test_check_data_status_marks_unsupported_raw_as_incomplete(
     assert "invalid.csv (未対応のファイル名)" in capsys.readouterr().out
 
 
+def test_check_data_status_rejects_nested_raw_sources(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    data_dir = tmp_path / "data"
+    raw_name = "notifiable_weekly_2025_01.csv"
+    _write_csv(data_dir / "raw" / "a" / raw_name, ["h1,h2", "1,2"])
+    _write_csv(data_dir / "raw" / "b" / raw_name, ["h1,h2", "1,2"])
+    _write_csv(data_dir / "processed" / "normalized_notifiable_weekly_2025_01.csv", ["h1,h2", "1,2"])
+
+    status = cds.check_status(data_dir)
+    coverage = status["coverage"]
+
+    assert coverage["processed_rate"] == 0.0
+    assert coverage["incomplete_sources"] == [
+        {"raw_file": "a/notifiable_weekly_2025_01.csv", "missing_outputs": [], "reason": "noncanonical_raw_path"},
+        {"raw_file": "b/notifiable_weekly_2025_01.csv", "missing_outputs": [], "reason": "noncanonical_raw_path"},
+    ]
+    assert coverage["orphaned_processed_files"] == ["normalized_notifiable_weekly_2025_01.csv"]
+    cds.print_status(status, verbose=True)
+    assert "a/notifiable_weekly_2025_01.csv (raw直下ではないファイル)" in capsys.readouterr().out
+
+
 @pytest.mark.parametrize(
     ("raw_name", "expected_outputs"),
     [
@@ -231,6 +251,27 @@ def test_check_data_status_print_dir_and_main(
         cds.main()
     assert exc.value.code == 1
     assert "データディレクトリが見つかりません" in capsys.readouterr().err
+
+
+def test_check_data_status_main_reports_scan_error(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    monkeypatch.setattr(sys, "argv", ["check-data-status", "--data-dir", str(data_dir)])
+
+    def raise_scan_error(*_args: object, **_kwargs: object) -> dict[str, object]:
+        raise OSError("permission denied")
+
+    monkeypatch.setattr(cds, "check_status", raise_scan_error)
+
+    with pytest.raises(SystemExit) as exc:
+        cds.main()
+
+    assert exc.value.code == 1
+    assert "データディレクトリの読み取りに失敗しました: permission denied" in capsys.readouterr().err
 
 
 def test_check_missing_main_paths(

--- a/tests/test_issue300_phase0_cli_core_coverage.py
+++ b/tests/test_issue300_phase0_cli_core_coverage.py
@@ -295,6 +295,31 @@ def test_check_data_status_accepts_only_gender_sections_present_in_raw(tmp_path:
     assert coverage["orphaned_processed_files"] == []
 
 
+def test_check_data_status_ignores_gender_sections_the_processor_cannot_extract(tmp_path: Path) -> None:
+    data_dir = tmp_path / "data"
+    _write_raw_csv(
+        data_dir / "raw" / "sentinel_weekly_age_2025_01.csv",
+        [
+            '性別,"女性"',
+            "年齢区分,インフルエンザ,RSウイルス",
+            "0歳,12,6",
+            '性別,"男性"',
+            "年齢区分,項目A,項目B",
+            "0歳,10,5",
+        ],
+    )
+    _write_csv(
+        data_dir / "processed" / "normalized_sentinel_weekly_age_female_2025_01.csv",
+        ["h1,h2", "1,2"],
+    )
+
+    coverage = cds.check_status(data_dir)["coverage"]
+
+    assert coverage["processed_rate"] == 100.0
+    assert coverage["incomplete_sources"] == []
+    assert coverage["orphaned_processed_files"] == []
+
+
 def test_check_data_status_print_dir_and_main(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:

--- a/tests/test_issue300_phase0_cli_core_coverage.py
+++ b/tests/test_issue300_phase0_cli_core_coverage.py
@@ -25,66 +25,156 @@ def _write_csv(path: Path, rows: list[str]) -> None:
 
 def test_check_data_status_directory_and_status_flow(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
     data_dir = tmp_path / "data"
-    _write_csv(data_dir / "raw" / "a.csv", ["h1,h2", "1,2"])
-    _write_csv(data_dir / "processed" / "a.csv", ["h1,h2", "1,2"])
-    _write_csv(data_dir / "processed" / "b.csv", ["h1,h2", "3,4"])
+    _write_csv(data_dir / "raw" / "sentinel_weekly_age_2025_01.csv", ["h1,h2", "1,2"])
+    for gender in ("male", "female", "total"):
+        _write_csv(
+            data_dir / "processed" / f"normalized_sentinel_weekly_age_{gender}_2025_01.csv",
+            ["h1,h2", "1,2"],
+        )
+    _write_csv(data_dir / "processed" / "normalized_notifiable_weekly_2025_99.csv", ["h1,h2", "3,4"])
 
     missing = cds.check_directory(data_dir / "missing")
     assert missing["exists"] is False
 
     verbose_dir = cds.check_directory(data_dir / "processed", verbose=True)
     assert verbose_dir["exists"] is True
-    assert verbose_dir["file_count"] == 2
-    assert len(verbose_dir["files"]) == 2
+    assert verbose_dir["file_count"] == 4
+    assert len(verbose_dir["files"]) == 4
 
     status = cds.check_status(data_dir, verbose=True)
-    assert status["coverage"]["processed_rate"] == pytest.approx(200.0)
+    assert status["coverage"] == {
+        "processed_rate": pytest.approx(100.0),
+        "raw_source_count": 1,
+        "processed_source_count": 1,
+        "incomplete_source_count": 0,
+        "incomplete_sources": [],
+        "orphaned_processed_count": 1,
+        "orphaned_processed_files": ["normalized_notifiable_weekly_2025_99.csv"],
+    }
+    cds.print_status(status, verbose=True)
+    out = capsys.readouterr().out
+    assert "すべての処理が完了しています" in out
+    assert "rawに対応しない処理済みファイル: 1件" in out
+    assert "normalized_notifiable_weekly_2025_99.csv" in out
+
     empty_status = cds.check_status(tmp_path / "empty-data", verbose=False)
     assert empty_status["coverage"]["processed_rate"] == 0.0
-
-    status_no_raw = {
-        "raw": {"exists": True, "file_count": 0, "total_size_mb": 0},
-        "processed": {"exists": True, "file_count": 0, "total_size_mb": 0},
-        "backups": {"exists": False, "file_count": 0, "total_size_mb": 0, "files": []},
-        "logs": {"exists": False, "file_count": 0, "total_size_mb": 0, "files": []},
-        "coverage": {"processed_rate": 0.0},
-    }
-    cds.print_status(status_no_raw, verbose=False)
+    assert empty_status["coverage"]["raw_source_count"] == 0
+    cds.print_status(empty_status, verbose=False)
     out = capsys.readouterr().out
     assert "data/raw/にデータがありません" in out
 
-    status_need_processing = {
-        "raw": {"exists": True, "file_count": 2, "total_size_mb": 0},
-        "processed": {"exists": True, "file_count": 0, "total_size_mb": 0},
-        "backups": {"exists": True, "file_count": 0, "total_size_mb": 0},
-        "logs": {"exists": True, "file_count": 0, "total_size_mb": 0},
-        "coverage": {"processed_rate": 0.0},
-    }
+    need_processing_dir = tmp_path / "need-processing"
+    _write_csv(need_processing_dir / "raw" / "notifiable_weekly_2025_01.csv", ["h1,h2", "1,2"])
+    status_need_processing = cds.check_status(need_processing_dir)
     cds.print_status(status_need_processing, verbose=False)
     out = capsys.readouterr().out
     assert "データ処理が必要です" in out
 
-    status_partial = {
-        "raw": {"exists": True, "file_count": 5, "total_size_mb": 0},
-        "processed": {"exists": True, "file_count": 3, "total_size_mb": 0},
-        "backups": {"exists": True, "file_count": 0, "total_size_mb": 0},
-        "logs": {"exists": True, "file_count": 0, "total_size_mb": 0},
-        "coverage": {"processed_rate": 60.0},
-    }
-    cds.print_status(status_partial, verbose=False)
+    partial_dir = tmp_path / "partial"
+    _write_csv(partial_dir / "raw" / "notifiable_weekly_2025_01.csv", ["h1,h2", "1,2"])
+    _write_csv(partial_dir / "processed" / "normalized_notifiable_weekly_2025_01.csv", ["h1,h2", "1,2"])
+    _write_csv(partial_dir / "raw" / "sentinel_weekly_age_2025_02.csv", ["h1,h2", "1,2"])
+    for gender in ("male", "female"):
+        _write_csv(
+            partial_dir / "processed" / f"normalized_sentinel_weekly_age_{gender}_2025_02.csv",
+            ["h1,h2", "1,2"],
+        )
+    status_partial = cds.check_status(partial_dir)
+    assert status_partial["coverage"]["processed_rate"] == pytest.approx(50.0)
+    assert status_partial["coverage"]["incomplete_sources"] == [
+        {
+            "raw_file": "sentinel_weekly_age_2025_02.csv",
+            "missing_outputs": ["normalized_sentinel_weekly_age_total_2025_02.csv"],
+        }
+    ]
+    cds.print_status(status_partial, verbose=True)
     out = capsys.readouterr().out
     assert "一部のファイルが処理されていません" in out
+    assert "normalized_sentinel_weekly_age_total_2025_02.csv" in out
 
-    status_done = {
-        "raw": {"exists": True, "file_count": 2, "total_size_mb": 0},
-        "processed": {"exists": True, "file_count": 2, "total_size_mb": 0},
-        "backups": {"exists": True, "file_count": 0, "total_size_mb": 0},
-        "logs": {"exists": True, "file_count": 0, "total_size_mb": 0},
-        "coverage": {"processed_rate": 100.0},
-    }
-    cds.print_status(status_done, verbose=False)
-    out = capsys.readouterr().out
-    assert "すべての処理が完了しています" in out
+
+def test_check_data_status_marks_unsupported_raw_as_incomplete(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    data_dir = tmp_path / "data"
+    _write_csv(data_dir / "raw" / "invalid.csv", ["h1,h2", "1,2"])
+    _write_csv(data_dir / "raw" / "unknown_2025_01.csv", ["h1,h2", "1,2"])
+    _write_csv(data_dir / "processed" / "normalized_invalid.csv", ["h1,h2", "1,2"])
+    _write_csv(data_dir / "processed" / "normalized_unknown_2025_01.csv", ["h1,h2", "1,2"])
+
+    status = cds.check_status(data_dir)
+    coverage = status["coverage"]
+
+    assert coverage["processed_rate"] == 0.0
+    assert coverage["incomplete_sources"] == [
+        {"raw_file": "invalid.csv", "missing_outputs": [], "reason": "unsupported_raw_filename"},
+        {"raw_file": "unknown_2025_01.csv", "missing_outputs": [], "reason": "unsupported_raw_filename"},
+    ]
+    assert coverage["orphaned_processed_files"] == [
+        "normalized_invalid.csv",
+        "normalized_unknown_2025_01.csv",
+    ]
+    cds.print_status(status, verbose=True)
+    assert "invalid.csv (未対応のファイル名)" in capsys.readouterr().out
+
+
+@pytest.mark.parametrize(
+    ("raw_name", "expected_outputs"),
+    [
+        ("notifiable_weekly_2025_01.csv", ["normalized_notifiable_weekly_2025_01.csv"]),
+        ("sentinel_weekly_gender_2025_01.csv", ["normalized_sentinel_weekly_gender_2025_01.csv"]),
+        (
+            "sentinel_weekly_age_2025_01.csv",
+            [
+                "normalized_sentinel_weekly_age_female_2025_01.csv",
+                "normalized_sentinel_weekly_age_male_2025_01.csv",
+                "normalized_sentinel_weekly_age_total_2025_01.csv",
+            ],
+        ),
+        (
+            "sentinel_weekly_health_center_2025_01.csv",
+            [
+                "normalized_sentinel_weekly_health_center_female_2025_01.csv",
+                "normalized_sentinel_weekly_health_center_male_2025_01.csv",
+                "normalized_sentinel_weekly_health_center_total_2025_01.csv",
+            ],
+        ),
+        (
+            "sentinel_weekly_medical_district_2025_01.csv",
+            [
+                "normalized_sentinel_weekly_medical_district_female_2025_01.csv",
+                "normalized_sentinel_weekly_medical_district_male_2025_01.csv",
+            ],
+        ),
+        ("sentinel_monthly_gender_2025_01.csv", ["normalized_sentinel_monthly_gender_2025_01.csv"]),
+        (
+            "sentinel_monthly_age_2025_01.csv",
+            [
+                "normalized_sentinel_monthly_age_female_2025_01.csv",
+                "normalized_sentinel_monthly_age_male_2025_01.csv",
+                "normalized_sentinel_monthly_age_total_2025_01.csv",
+            ],
+        ),
+        (
+            "sentinel_monthly_health_center_2025_01.csv",
+            [
+                "normalized_sentinel_monthly_health_center_female_2025_01.csv",
+                "normalized_sentinel_monthly_health_center_male_2025_01.csv",
+                "normalized_sentinel_monthly_health_center_total_2025_01.csv",
+            ],
+        ),
+        (
+            "sentinel_monthly_medical_district_2025_01.csv",
+            [
+                "normalized_sentinel_monthly_medical_district_female_2025_01.csv",
+                "normalized_sentinel_monthly_medical_district_male_2025_01.csv",
+            ],
+        ),
+    ],
+)
+def test_check_data_status_defines_expected_outputs_per_data_type(raw_name: str, expected_outputs: list[str]) -> None:
+    assert cds.expected_processed_outputs(raw_name) == expected_outputs
 
 
 def test_check_data_status_print_dir_and_main(
@@ -99,8 +189,8 @@ def test_check_data_status_print_dir_and_main(
     assert "他 1件" in out
 
     data_dir = tmp_path / "d"
-    _write_csv(data_dir / "raw" / "a.csv", ["h1,h2", "1,2"])
-    _write_csv(data_dir / "processed" / "a.csv", ["h1,h2", "1,2"])
+    _write_csv(data_dir / "raw" / "notifiable_weekly_2025_01.csv", ["h1,h2", "1,2"])
+    _write_csv(data_dir / "processed" / "normalized_notifiable_weekly_2025_01.csv", ["h1,h2", "1,2"])
 
     monkeypatch.setattr(sys, "argv", ["check-data-status", "--data-dir", str(data_dir), "--json"])
     cds.main()


### PR DESCRIPTION
## 概要

`check-data-status` の処理カバー率を、processed CSV総数ではなく、必要な成果物がすべて揃ったraw source数から算出します。

Closes #595

## 原因と影響

1つのrawから複数のprocessed CSVを生成する設計に対して、従来は単純なファイル数の比率を使っていました。そのため処理済み率が100%を超え、一部のrawが未処理でも完了扱いになる可能性がありました。

## 変更内容

- 9データ種別ごとの期待成果物を一箇所で定義
- rawごとに必要な成果物セットの充足を判定
- 未処理・一部欠損rawと、rawに対応しない孤立processedをJSONへ出力
- `--verbose` で欠損成果物と孤立processedの一覧を表示
- 推奨アクションの完了判定をsource単位へ変更
- 単一出力、複数出力、suffixなしフォールバック、一部欠損、孤立processed、0件、未対応ファイル名、nested rawを回帰テストで検証
- ファイル走査時のI/Oエラーをstderrと非ゼロ終了でfail-closedに処理
- 再処理できないrawは、`process-data`ではなくファイル名・配置の修正を案内

## 実データでの結果

- raw: 8,168件
- processed CSV: 16,287件
- 従来表示: 199.4%
- 修正後: 97.70% (完了7,980件 / 未完了188件)
- 孤立processed: 0件

## 検証

- `uv sync --all-extras --locked`
- `uv run pre-commit run --files src/cli/check_data_status.py tests/test_issue300_phase0_cli_core_coverage.py`
- `uv run pytest tests/ --cov=src --cov-report=term-missing --cov-branch --cov-fail-under=100 -q -p no:warnings`
  - 717 passed
  - statement / branch coverage 100%
- `uv run check-data-status --json`
  - 実データで完了7,980 / 8,168件、未完了188件、孤立processed 0件を確認


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


* **改善**
  * データ処理状況を、rawファイル単位の完了数と未完了数で確認できるようになりました。
  * 未処理のrawファイル、対応付けできないprocessedファイル、処理できない理由を確認できます。
  * 詳細表示では、不足している成果物や対象外ファイルの一覧を表示します。
  * データ種別や性別区分に応じた期待成果物の判定精度を向上しました。

* **バグ修正**
  * データ確認時の読み取りエラーを適切に検知し、明確なエラーメッセージを表示するよう改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->