### PR TITLE
chore(deps): Requests本体の型情報へ移行

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -71,7 +71,7 @@ repos:
       - id: mypy
         name: Python型チェック
         args: ["--ignore-missing-imports", "--no-strict-optional", "--python-version=3.11"]
-        additional_dependencies: [types-PyYAML]
+        additional_dependencies: [requests==2.34.2, types-PyYAML]
 
   # Markdownファイルのフォーマット
   # mirrors-prettier (pre-commit 公式) は 2024 年にアーカイブされたため後継の rbubley/mirrors-prettier を使用

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -71,7 +71,7 @@ repos:
       - id: mypy
         name: Python型チェック
         args: ["--ignore-missing-imports", "--no-strict-optional", "--python-version=3.11"]
-        additional_dependencies: [types-requests, types-PyYAML]
+        additional_dependencies: [types-PyYAML]
 
   # Markdownファイルのフォーマット
   # mirrors-prettier (pre-commit 公式) は 2024 年にアーカイブされたため後継の rbubley/mirrors-prettier を使用

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,6 @@ dev = [
     "ruff>=0.15.21",
     "mypy>=2.2.0",
     "isort>=5.12.0",
-    "types-requests>=2.33.0.20260712",
     "types-PyYAML>=6.0.1",
     "pre-commit>=4.6.0",
     "jsonschema>=4.18.0",

--- a/tests/test_dependabot_config.py
+++ b/tests/test_dependabot_config.py
@@ -1,5 +1,7 @@
+import tomllib
 from pathlib import Path
 
+import requests
 import yaml
 
 
@@ -15,3 +17,18 @@ def test_all_dependabot_version_updates_have_seven_day_cooldown():
     ]
 
     assert invalid_ecosystems == []
+
+
+def test_requests_uses_bundled_type_information():
+    project_root = Path(__file__).resolve().parent.parent
+    pyproject = tomllib.loads((project_root / "pyproject.toml").read_text(encoding="utf-8"))
+    pre_commit = yaml.safe_load((project_root / ".pre-commit-config.yaml").read_text(encoding="utf-8"))
+    lock_text = (project_root / "uv.lock").read_text(encoding="utf-8")
+
+    dev_dependencies = pyproject["project"]["optional-dependencies"]["dev"]
+    mypy_hook = next(hook for repo in pre_commit["repos"] for hook in repo["hooks"] if hook["id"] == "mypy")
+
+    assert not any(dependency.startswith("types-requests") for dependency in dev_dependencies)
+    assert "types-requests" not in mypy_hook["additional_dependencies"]
+    assert 'name = "types-requests"' not in lock_text
+    assert (Path(requests.__file__).parent / "py.typed").is_file()

--- a/tests/test_dependabot_config.py
+++ b/tests/test_dependabot_config.py
@@ -1,4 +1,5 @@
 import tomllib
+from importlib.metadata import version
 from pathlib import Path
 
 import requests
@@ -30,5 +31,6 @@ def test_requests_uses_bundled_type_information():
 
     assert not any(dependency.startswith("types-requests") for dependency in dev_dependencies)
     assert "types-requests" not in mypy_hook["additional_dependencies"]
+    assert f"requests=={version('requests')}" in mypy_hook["additional_dependencies"]
     assert 'name = "types-requests"' not in lock_text
     assert (Path(requests.__file__).parent / "py.typed").is_file()

--- a/tests/test_dependabot_config.py
+++ b/tests/test_dependabot_config.py
@@ -1,3 +1,5 @@
+import subprocess
+import sys
 import tomllib
 from importlib.metadata import version
 from pathlib import Path
@@ -20,11 +22,13 @@ def test_all_dependabot_version_updates_have_seven_day_cooldown():
     assert invalid_ecosystems == []
 
 
-def test_requests_uses_bundled_type_information():
+def test_requests_uses_bundled_type_information(tmp_path: Path) -> None:
     project_root = Path(__file__).resolve().parent.parent
     pyproject = tomllib.loads((project_root / "pyproject.toml").read_text(encoding="utf-8"))
     pre_commit = yaml.safe_load((project_root / ".pre-commit-config.yaml").read_text(encoding="utf-8"))
     lock_text = (project_root / "uv.lock").read_text(encoding="utf-8")
+    invalid_requests_usage = tmp_path / "invalid_requests_usage.py"
+    invalid_requests_usage.write_text("import requests\nrequests.get(123)\n", encoding="utf-8")
 
     dev_dependencies = pyproject["project"]["optional-dependencies"]["dev"]
     mypy_hook = next(hook for repo in pre_commit["repos"] for hook in repo["hooks"] if hook["id"] == "mypy")
@@ -34,3 +38,14 @@ def test_requests_uses_bundled_type_information():
     assert f"requests=={version('requests')}" in mypy_hook["additional_dependencies"]
     assert 'name = "types-requests"' not in lock_text
     assert (Path(requests.__file__).parent / "py.typed").is_file()
+
+    result = subprocess.run(
+        [sys.executable, "-m", "mypy", "--no-error-summary", str(invalid_requests_usage)],
+        cwd=project_root,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 1
+    assert 'Argument 1 to "get" has incompatible type "int"' in result.stdout

--- a/tests/test_issue302_phase1_coverage.py
+++ b/tests/test_issue302_phase1_coverage.py
@@ -26,10 +26,10 @@ import csv
 import subprocess
 from datetime import UTC, datetime
 from pathlib import Path
-from types import SimpleNamespace
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
+from requests import Response
 from requests.exceptions import HTTPError
 
 from src.fetchers.enhanced_fetcher import DataFetcherConfig, EnhancedEpidemicDataFetcher, FetchResult, RetryHandler
@@ -109,7 +109,10 @@ def test_config_manager_get_enabled_data_types_loads_config_when_missing() -> No
 def _make_http_error(status_code: int, headers: dict[str, str] | None = None) -> HTTPError:
     """Helper to create HTTPError with specific status code and headers."""
     error = HTTPError("http error")
-    error.response = SimpleNamespace(status_code=status_code, headers=headers or {})
+    response = Response()
+    response.status_code = status_code
+    response.headers.update(headers or {})
+    error.response = response
     return error
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -769,7 +769,6 @@ dev = [
     { name = "pytest-cov" },
     { name = "ruff" },
     { name = "types-pyyaml" },
-    { name = "types-requests" },
 ]
 
 [package.metadata]
@@ -788,7 +787,6 @@ requires-dist = [
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.15.21" },
     { name = "seaborn", specifier = ">=0.13.2" },
     { name = "types-pyyaml", marker = "extra == 'dev'", specifier = ">=6.0.1" },
-    { name = "types-requests", marker = "extra == 'dev'", specifier = ">=2.33.0.20260712" },
 ]
 provides-extras = ["dev"]
 
@@ -816,18 +814,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/7e/69/3c51b36d04da19b92f9e815be12753125bd8bc247ba0470a982e6979e71c/types_pyyaml-6.0.12.20250915.tar.gz", hash = "sha256:0f8b54a528c303f0e6f7165687dd33fafa81c807fcac23f632b63aa624ced1d3", size = 17522, upload-time = "2025-09-15T03:01:00.728Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/bd/e0/1eed384f02555dde685fff1a1ac805c1c7dcb6dd019c916fe659b1c1f9ec/types_pyyaml-6.0.12.20250915-py3-none-any.whl", hash = "sha256:e7d4d9e064e89a3b3cae120b4990cd370874d2bf12fa5f46c97018dd5d3c9ab6", size = 20338, upload-time = "2025-09-15T03:00:59.218Z" },
-]
-
-[[package]]
-name = "types-requests"
-version = "2.33.0.20260712"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "urllib3" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/db/51/703318f7b7be8bee126ec13bf615050f932d0179b8784420f3a0199cc769/types_requests-2.33.0.20260712.tar.gz", hash = "sha256:2141b67ab534a5c5cd2dac5034f2a35f42e699c5bf185eee608c5246a069d7fb", size = 25084, upload-time = "2026-07-12T05:14:20.455Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/62/e7/010c87f559e216d83f9dc51e939633fd0d0ead3377340181ab0e223cd3b5/types_requests-2.33.0.20260712-py3-none-any.whl", hash = "sha256:de027e28c171d3da529689cbfa023b0b4eab188c8dfa22fd834eebd2cee6e7bb", size = 21392, upload-time = "2026-07-12T05:14:19.616Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## 概要

Requests 2.34.2本体の型情報を使用するようにし、2.33系向けの外部`types-requests`を削除します。

Closes #597

## 変更内容

- optional dev依存から`types-requests`を削除
- pre-commitのmypy追加依存から`types-requests`を削除
- `uv.lock`からstub packageを削除
- Requests本体の`py.typed`と外部stub不在を確認する回帰テストを追加

## 根拠

- types-requests公式はRequests 2.34.0以降では本体に型注釈・stubが含まれるためアンインストールするよう案内
  - https://pypi.org/project/types-requests/
- Requests 2.34.0はinline types導入をリリースノートに明記
  - https://github.com/psf/requests/releases/tag/v2.34.0

## 検証

- `uv sync --all-extras --locked`
- `uv run pre-commit run --files pyproject.toml uv.lock .pre-commit-config.yaml tests/test_dependabot_config.py`
- `uv run mypy src scripts --ignore-missing-imports --no-strict-optional`
  - 35 source files、issue 0件
- `uv run mypy -c "import requests; reveal_type(requests.Session); reveal_type(requests.Response)" --no-error-summary`
  - `requests.sessions.Session` / `requests.models.Response`として解決
- `uv run pytest tests/ --cov=src --cov-report=term-missing --cov-branch --cov-fail-under=100 -q -p no:warnings`
  - 724 passed、statement/branch coverage 100%
- `rg "types-requests" pyproject.toml uv.lock .pre-commit-config.yaml`
  - 0件

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **依存関係**
  * 開発用の型チェック環境から `types-requests` を外し、`requests==2.34.2` と `types-PyYAML` を追加しました。
* **テスト**
  * `requests` が同梱する型情報に依存していることを確認するテストを追加しました。
  * HTTPエラー関連テストの準備を整理し、参照用オブジェクトの作り方を `requests.Response` に合わせて更新しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->